### PR TITLE
Fixed code mistake keeping Krytos pink

### DIFF
--- a/game/npcs/krytos/model.mdf
+++ b/game/npcs/krytos/model.mdf
@@ -7,12 +7,12 @@
 		<reference mesh="model_high" material="material.material" />		
 	</skin>
 	
-	<skin name="pink">		
+	<skin name="black">		
 		<reference mesh="model_high" material="material_black.material"/>	
 	</skin>	
 	
 	<!-- Pink Update -->
-	<skin name="default">		
+	<skin name="pink">		
 		<reference mesh="model_high" material="material_pink.material"/>	
 	</skin>	
 


### PR DESCRIPTION
By mistake wrong skin was renamed in Krytos files, which in result kept him pink. That mistake was fixed.