### PR TITLE
Disabled effects and voicelines for store preview

### DIFF
--- a/game/ui/main/pregame/pregame.lua
+++ b/game/ui/main/pregame/pregame.lua
@@ -2010,7 +2010,6 @@ local function DisplayDyePreviewModel(skin, dye, specialEdition)
 		local AltAvatarTrigger = LuaTrigger.GetTrigger('HeroSelectHeroAltAvatarList'..skin)
 		ownGear = AltAvatarTrigger.canSelect
 		SetModel(main_pregame_dye_selection_heromodel, AltAvatarTrigger.modelPath)
-		main_pregame_dye_selection_heromodel:SetEffect(HeroSelectLocalPlayerInfo.previewPassiveEffect)
 		main_pregame_dye_selection_heromodel:SetModelOrientation(AltAvatarTrigger.previewAngles)
 		main_pregame_dye_selection_heromodel:SetModelPosition(AltAvatarTrigger.previewPos)
 		main_pregame_dye_selection_heromodel:SetModelScale(AltAvatarTrigger.previewScale)


### PR DESCRIPTION
Currently as you browse hero skins, they are surrounded with same effects as in queue screen, which often makes it hard to see skin itself (Bo is the worst example). And every switch of dye triggers voiceline, which is annoying. With removal of a single line I disabled both effect and sound from store preview, while keeping effects and sounds in queue preview.