### PR TITLE
TitanSlayer against Iceforged Plate fix

### DIFF
--- a/game/items/recipes/defensive/shardplate/state_empower_3.entity
+++ b/game/items/recipes/defensive/shardplate/state_empower_3.entity
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<state
+	name="State_Shardplate_Empower_3"
+	allowtransfer="true"
+	ishidden="true"
+>
+
+	<onattackeddamageevent>
+		<damagesupertype supertype="attack">
+			<getconstant name="damagereduction_enchant" adjustmentsource="tool_entity"/>
+			<setvar0 a="result" b="100" op="div" />
+			<setvar1 a="damage_attempted" b="var0" op="mult" />
+			<setvar2 a="1" b="var0" op="sub" />
+			<setvalue name="damage_attempted" a="damage_attempted" b="var2" op="mult" />
+			<damage target="this_inflictor_entity" effecttype="AttackDamage" amount="1" b="var1" op="mult" nonlethal="true" />
+			<!-- effect & popup -->
+			<playeffect effect="effects/self/impact.effect" source="this_inflictor_entity" target="this_inflictor_entity" />
+			<popup name="attackdamage" source="this_inflictor_entity" target="this_inflictor_entity" a="var1" />
+		</damagesupertype>
+	</onattackeddamageevent>    
+
+	
+</state>

--- a/game/items/recipes/defensive/shardplate/state_empower_3.entity
+++ b/game/items/recipes/defensive/shardplate/state_empower_3.entity
@@ -12,7 +12,7 @@
 			<setvar1 a="damage_attempted" b="var0" op="mult" />
 			<setvar2 a="1" b="var0" op="sub" />
 			<setvalue name="damage_attempted" a="damage_attempted" b="var2" op="mult" />
-			<damage target="this_inflictor_entity" effecttype="AttackDamage" amount="1" b="var1" op="mult" nonlethal="true" />
+			<damage target="this_inflictor_entity" effecttype="Indirect" amount="1" b="var1" op="mult" nonlethal="true" />
 			<!-- effect & popup -->
 			<playeffect effect="effects/self/impact.effect" source="this_inflictor_entity" target="this_inflictor_entity" />
 			<popup name="attackdamage" source="this_inflictor_entity" target="this_inflictor_entity" a="var1" />


### PR DESCRIPTION
Player with Titanslayer dealt extra damage to enemy with Iceforged Plate with Command enchant if Titanslayer player attacked other players. The problem was that Titanslayer applies to "AttackDamage" and enchantments redirects damage as AttackDamage  as well. I changed Iceforged Plate redirected damage to "Indirect" and that solved half of the problem: extra damage.
After the fix I found out that extra damage added after reduction from Iceforged Plate. That part is fixed in strife-game: [related issue](https://github.com/strife-community/strife-game/pull/10).
This PR is not required to be merged together with [related issue](https://github.com/strife-community/strife-game/pull/10), but it is recommended.