### PR TITLE
Fixed background images scale for high resolution monitors

### DIFF
--- a/game/ui/main/background/main_background2.package
+++ b/game/ui/main/background/main_background2.package
@@ -124,6 +124,6 @@
 	</panel>
 	<panel name="pregame_splashimage_container" y="90s" height="-90s" visible="0" noclick="1"/>
 	
-	<splashimage name="wheel_background" onshowlua="self:SetImage('/ui/main/shared/concept_art/prematch_background.jpg')" onhidelua="self:SetImage('')" noclick="1" visible="0" />
+	<splashimage name="wheel_background" onshowlua="self:SetImage('/ui/main/shared/concept_art/prematch_background.jpg')" onhidelua="self:SetImage('')" noclick="1" visible="0" view="stretch" />
 	
 </package>

--- a/game/ui/main/background/main_background2.package
+++ b/game/ui/main/background/main_background2.package
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package>
+
+	<panel name="mainBG" texture="/ui/main/shared/textures/main_background.tga" width="178.777778@" height="100%" align="center"/>
+
+	<!-- play screen background -->
+	<template name="selection_background" >
+		<panel name="selection_background" noclick="1" texture="$invis" color="1 1 1 1" visible="0" >		
+		</panel>	
+	</template>	
+	
+	<!-- big wheel -->
+	<panel name="mainBGWheel_parent" width="127h" height="127h" valign="center" x="-250s" noclick="true" passivechildren="true">
+		 
+		<!-- BEHIND WHEEL GLOW -->
+		<panel name="mainBG_behind_glow" width="205w" height="200h" align="center" valign="center" color="invisible" noclick="1" >
+			<modelpanel name="mainBG_behind_glow_modelpanel"
+				noclick="true"
+				model="/shared/models/invis.mdf"
+				effect="" 
+				camerapos="0 -40 0"
+				cameraangles="0 0 0"
+				camerafov="55"
+				depthclear="true"
+				depthcompress="true"
+				onloadlua="
+					self:SetEffect('/ui/main/background/blue/main_bg.effect', '1', '1', '1')
+				"
+			/>
+		</panel>	
+		
+		<panel height="100h" width="100w" x="58.5h" y="9.0h" >
+			<instance name="selection_background" />	
+		</panel>
+		
+		<image name="mainBGWheel_shadow" visible="0" texture="/ui/shared/textures/bg_wheel_texture_glow.tga" width="126@" height="126%" align="center" valign="center" color="0 0 0 0.45" noclick="true"/>		
+
+		<!-- WHEEL MODEL -->
+		<modelpanel name="mainBGWheel" width="252@" height="252%" align="center" valign="center" visible="1"
+
+			model="/ui/main/background/blue/model/model.mdf"
+			
+			effect=""
+			
+			onloadlua="
+				self:SetEffect('/ui/main/background/blue/front.effect', '1', '1', '1')
+			"
+			
+			depthclear="true" 
+			depthcompress="false"
+			lookat="false"
+			
+			modelscale="0.5"
+			modelpos="0 -1350 0"
+			modelangles="0 0 0" 
+
+			anim="idle"	
+			rotation="0"
+			ambientcolor=".5 .5 .5"
+		/>		
+		
+		<!-- BEHIND RANKED GLOW -->
+		<panel name="mainBG_behind_ranked_glow" visible="0" width="205w" height="200h" align="center" valign="center" color="invisible" noclick="1" >
+			<modelpanel name="mainBG_behind_ranked_glow_modelpanel"
+				noclick="true"
+				model="/shared/models/invis.mdf"
+				effect="" 
+				camerapos="0 -40 0"
+				cameraangles="0 0 0"
+				camerafov="55"
+				depthclear="true"
+				depthcompress="true"
+				onloadlua="
+					self:SetEffect('/ui/main/background/main_bg.effect', '0.85', '0.52', '0.40')
+				"
+			/>
+		</panel>		
+		
+		<modelpanel name="mainBGWheel_ranked" visible="0" width="252@" height="252%" align="center" valign="center"
+
+			XXXmodel="/ui/shared/models/ranked_wheel/test/model.mdf"
+			ZZZmodel="/ui/main/background/ranked/div_silver/model.mdf"
+			model="/ui/main/background/ranked/div_silver/model.mdf"
+			
+			effect=""
+			
+			onloadlua="
+				--self:Sleep(1000, function(self) self:SetVisible(1) end)
+				--self:SetEffect('/ui/main/background/blue/front.effect', '1', '1', '1')
+			"
+			
+			depthclear="true" 
+			depthcompress="false"
+			lookat="false"
+			
+			modelscale="20"
+			modelpos="-20 -250 0"
+			modelangles="0 0 0" 
+
+			anim="idle"	
+			rotation="0"
+			ambientcolor=".5 .5 .5"
+		/>		
+
+		<image name="mainBGWheel_texture" visible="0" texture="$invis" width="100@" height="100%" align="center" valign="center"  color="1 1 1 1" noclick="true"/>			
+		
+		<image name="mainBGWheel_shadow_2" visible="1" texture="/ui/shared/textures/bg_wheel_texture_glow.tga" width="126@" height="126%" align="center" valign="center" color="0 0 0 .1" noclick="true"/>		
+
+	</panel>	
+	
+	<panel name="mainBackgroundBlackTop" height="90s" color="black" visible="0" noclick="1"/>
+
+	<panel name="preview_splash" noclick="1" passivechildren="true" color="invisible" y="0" visible="0" >
+		<image texture="/ui/main/background/textures/dhw_logo.tga" x="45s" y="-65s" valign="bottom" width="360s" height="180s" noclick="1" />
+	</panel>	
+
+	<frame name="main_bg_loading_bar_frame" texture="/ui/elements:rounded_bg_white" width="40h" height="1.5h" align="center" valign="bottom" y="-20%" x="40%" color="1 1 1 1.0" borderthickness="0.5h" noclick="1" clip="true" visible="0">
+		<frame name="main_bg_loading_bar" texture="/ui/elements:rounded_bg_white" onshowlua="self:SetWidth('5%')" width="5%" height="1.5h" color="1 0 0 1.0" borderthickness="0.5h" noclick="1" />
+	</frame>	
+	  
+	<!-- container for pregame splash images to cover the background with -->
+	<panel name="pregame_loading_background" y="90s" height="-90s" visible="0" color="black" noclick="1">
+		<label content="pregame_general_loading" y="-100s" font="maindyn_36" style="labelBase" color="#b9f9ff99" textalign="center" textvalign="center" noclick="1"/>
+	</panel>
+	<panel name="pregame_splashimage_container" y="90s" height="-90s" visible="0" noclick="1"/>
+	
+	<splashimage name="wheel_background" onshowlua="self:SetImage('/ui/main/shared/concept_art/prematch_background.jpg')" onhidelua="self:SetImage('')" noclick="1" visible="0" />
+	
+</package>

--- a/game/ui/main/postgame/postgame.package
+++ b/game/ui/main/postgame/postgame.package
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package>
+	<include file="postgame_templates.package"/>
+
+	<panel name="post_game_loop_parent" noclick="1" visible="0" 
+		onshowlua="
+			mainUI.resourceContextTable	= mainUI.resourceContextTable or {}
+			mainUI.resourceContextTable.rewards_bg_texture = true		
+		"
+		onhidelua="
+			self:Sleep(1, function(self)
+				if (mainUI.resourceContextTable) and (mainUI.resourceContextTable.rewards_bg_texture) then
+					self:UICmd('DeleteResourceContext(\'rewards_bg_texture\')')
+				end
+			end)
+		"	
+	>
+
+		<!-- Postgame Background -->
+		<panel name="postgame_enviro_background" width="100%" color="0 0 0 1" height="100%" noclick="1" visible="1">
+		
+			<splashimage
+				noclick="1"
+				visible="1"
+				height="63.49@" width="100%"
+				onhidelua="self:SetImage('')"
+				onshowlua="self:SetImage('/ui/main/postgame/textures/enviro_base_0.jpg')"
+			/>
+			
+			
+			<modelpanel
+				noclick="true"
+				height="75%"
+				model="/shared/models/invis.mdf"
+				camerapos="-240 0 -30"
+				cameraangles="0 0 0"
+				camerafov="50"
+				depthclear="true"
+				depthcompress="true"
+				onloadlua="
+					self:SetEffect('/ui/main/postgame/effects/sun_rays.effect', '1', '1', '1')
+				"
+			/>
+			
+			
+			<panel width="2048s" height="1024s" noclick="1" valign="bottom"
+				texture="" onhidelua="self:SetTexture('')" onshowlua="self:SetTexture('/ui/main/postgame/textures/enviro_base_1.tga') self:SetColor('1 1 1 1')"
+			/>
+						
+		</panel>
+				
+		<instance name="postgame_khanquest_template" />
+		<instance name="postgame_rewards_template" />
+		<instance name="postgame_progress_template" />
+		
+		<!-- Postgame Foreground-->
+		<panel name="postgame_enviro_foreground" y="-15s" valign="bottom" noclick="1" visible="1">		
+			<panel x="0" width="920s" height="460s" valign="bottom" noclick="1"
+				texture="" onhidelua="self:SetTexture('')" onshowlua="self:SetTexture('/ui/main/postgame/textures/rockshelf.tga') self:SetColor('1 1 1 1')"
+			/>
+				
+		</panel>		
+		
+		<instance name="postgame_summary_template" />
+		
+		<panel name="postgame_summary_freeform_parent" noclick="1" >
+			<!-- Animated Rewards are inserted here -->
+		</panel>		
+		
+		<instance name="postgame_notice_parent_template" />
+		
+		<instance name="postgame_scoreboard_template" />
+		<instance name="postgame_nav_template" />
+		
+		<panel y="-10s" x="-5s" width="260s" height="124s" valign="bottom" noclick="1"
+			texture="" onhidelua="self:SetTexture('')" onshowlua="self:SetTexture('/ui/main/postgame/textures/rockshelf_foregrass.tga') self:SetColor('1 1 1 1')"
+		/>	
+
+	</panel>
+	
+	<lua file="/ui/main/postgame/quest_progress/quest_progress.lua"/>
+	<lua file="/ui/main/postgame/splash/postgame_splash.lua"/>
+	<lua file="/ui/main/postgame/khanquest/khanquest.lua"/>
+	<lua file="/ui/main/postgame/rewards/rewards.lua"/> 			<!-- move this in to rewards when seperated -->
+	<lua file="/ui/main/postgame/scoreboard/scoreboard.lua"/> 		<!-- move this in to scoreboard when awards seperated -->
+	<lua file="/ui/main/postgame/postgame.lua"/>
+	
+</package>

--- a/game/ui/main/postgame/postgame.package
+++ b/game/ui/main/postgame/postgame.package
@@ -23,6 +23,7 @@
 				noclick="1"
 				visible="1"
 				height="63.49@" width="100%"
+				view="stretch"
 				onhidelua="self:SetImage('')"
 				onshowlua="self:SetImage('/ui/main/postgame/textures/enviro_base_0.jpg')"
 			/>

--- a/game/ui/main/pregame/pregame.package
+++ b/game/ui/main/pregame/pregame.package
@@ -653,6 +653,7 @@
 			<splashimage
 				name="main_pregame_ready_container_background"
 				y="-14s" width="178.777778@" height="100%"
+				view="stretch"
 				align="center"
 				noclick="true"
 				onshowlua="self:SetImage('/ui/main/pregame/textures/ready_background.jpg')"


### PR DESCRIPTION
Could be related to https://github.com/strife-community/strife-patches/issues/113

Affects screens:
- Ready
- After game stats
- Wheel

Before:
<table>
<td>
<img src="https://github.com/user-attachments/assets/89dcd0ce-9f43-45a2-baa6-7ddc92987e62">
</td>
<td>
<img src="https://github.com/user-attachments/assets/f55ef084-2c59-4746-93b7-5c8cc91adccb">
</td>
<td>
<img src="https://github.com/user-attachments/assets/dc8a0147-06c9-4834-9a04-6998be2cfdf4">
</td>
</tr>
</table>

After:
<table>
<td>
<img src="https://github.com/user-attachments/assets/ac67aaca-2d3e-4ca5-ba2e-deceaf2d4e2d">
</td>
<td>
<img src="https://github.com/user-attachments/assets/c871bf21-8cf7-4081-af0e-8d449f17863b">
</td>
<td>
<img src="https://github.com/user-attachments/assets/347fdba1-f1e4-43bd-957c-959df6f641d5">
</td>
</tr>
</table>