### PR TITLE
Fixed Midknight E triggering on debuffs

### DIFF
--- a/game/heroes/midknight/ability_03/ability.entity
+++ b/game/heroes/midknight/ability_03/ability.entity
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ability
+	name="Ability_Midknight3"
+
+	icon="icon.tga"
+	
+	anim="ability_3"
+	casttime="0"
+	castactiontime="0"
+
+	maxlevel="4"
+	requiredlevel="1,3,5,7"
+	queue="front"
+	inheritmovement="true"
+	nostun="true"
+	noperplex="true"
+	nosilence="true"
+
+	actiontype="target_self"
+	casteffect=""
+	
+	manacost="50"
+	cooldowntime="24000,18000,14000,12000"
+	
+>
+
+	<constant name="power" value="20,30,40,50" adjustment="none" />
+	<!--tooltip only -->
+	<constant name="movespeed" value="75" adjustment="none" noshowintooltip="true" />
+	
+	<onimpact>
+		<haseffecttype name="CrowdControl StatusDisable StatusDebuff">
+			<applystate name="State_Midknight_Ability3_Buff" target="source_entity" duration="5000" />
+			<dispel type="CrowdControl" />
+			<dispel type="StatusDisable" />
+			<dispel type="StatusDebuff" />
+			<popup name="ccbreak" source="source_entity" target="source_entity" />
+			<playeffect effect="effects/shield_explosion.effect" target="source_entity" source="source_entity" />
+		</haseffecttype>
+			<else>
+			<applystate name="State_Midknight_Ability3" target="source_entity" duration="3000" />
+			</else>
+	</onimpact>
+	
+	
+</ability>

--- a/game/heroes/midknight/ability_03/ability.entity
+++ b/game/heroes/midknight/ability_03/ability.entity
@@ -29,11 +29,10 @@
 	<constant name="movespeed" value="75" adjustment="none" noshowintooltip="true" />
 	
 	<onimpact>
-		<haseffecttype name="CrowdControl StatusDisable StatusDebuff">
+		<haseffecttype name="CrowdControl StatusDisable">
 			<applystate name="State_Midknight_Ability3_Buff" target="source_entity" duration="5000" />
 			<dispel type="CrowdControl" />
 			<dispel type="StatusDisable" />
-			<dispel type="StatusDebuff" />
 			<popup name="ccbreak" source="source_entity" target="source_entity" />
 			<playeffect effect="effects/shield_explosion.effect" target="source_entity" source="source_entity" />
 		</haseffecttype>


### PR DESCRIPTION
Midknight E activation will no longer trigger on debuffs that are not slows or stuns (like Harrower's E).