### PR TITLE
Buford W agression fix

### DIFF
--- a/game/heroes/buford/ability_02/gadget.entity
+++ b/game/heroes/buford/ability_02/gadget.entity
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gadget
+	name="Gadget_Buford_Ability2"
+
+	icon=""
+	portrait=""
+	model=""
+	passiveeffect=""
+	deatheffect=""
+	
+	preglobalscale="1.0"
+	modelscale="1.5"
+	effectscale="0.9"
+	boundsheight="0"
+	radiusheight="0"
+	boundsradius="0"
+	isselectable="false"
+	selectionradius="0"
+	targetoffset="0 0 0"
+
+	canrotate="false"
+	ismobile="false"
+
+	attacktype="none"
+	combattype="Ranged"
+	canattack="false"
+
+	sightrangeday="0"
+	sightrangenight="0"
+	
+	buildingwalking="true"
+
+	deathtime="0"
+	corpsetime="0"
+
+	lifetime="6000"
+
+	invulnerable="true"
+	hidealtinfo="true"
+	flying="true"
+	flyheight="150"
+	clearvision="true"
+	drawonmap="false"
+	
+	hazardradius="250"
+
+	alwaystransmitdata="true"
+	
+	
+	
+>
+
+
+	<onframe>
+		<lineofeffect
+			radius="120"
+			start="this_entity"
+			end="this_proxy_entity"
+			targetselection="all"
+			targetscheme="enemy_units_and_buildings"
+			effecttype="Magic"
+		>
+				<applystate name="State_Buford_Ability2_Burn" continuous="true" timeout="frametime" />
+		
+				
+			
+		</lineofeffect>
+	
+		<recordheroaggression  />
+				<aggression />
+	</onframe>
+
+
+</gadget>

--- a/game/heroes/buford/ability_02/gadget.entity
+++ b/game/heroes/buford/ability_02/gadget.entity
@@ -1,74 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gadget
-	name="Gadget_Buford_Ability2"
+    name="Gadget_Buford_Ability2"
 
-	icon=""
-	portrait=""
-	model=""
-	passiveeffect=""
-	deatheffect=""
-	
-	preglobalscale="1.0"
-	modelscale="1.5"
-	effectscale="0.9"
-	boundsheight="0"
-	radiusheight="0"
-	boundsradius="0"
-	isselectable="false"
-	selectionradius="0"
-	targetoffset="0 0 0"
+    icon=""
+    portrait=""
+    model=""
+    passiveeffect=""
+    deatheffect=""
+    
+    preglobalscale="1.0"
+    modelscale="1.5"
+    effectscale="0.9"
+    boundsheight="0"
+    radiusheight="0"
+    boundsradius="0"
+    isselectable="false"
+    selectionradius="0"
+    targetoffset="0 0 0"
 
-	canrotate="false"
-	ismobile="false"
+    canrotate="false"
+    ismobile="false"
 
-	attacktype="none"
-	combattype="Ranged"
-	canattack="false"
+    attacktype="none"
+    combattype="Ranged"
+    canattack="false"
 
-	sightrangeday="0"
-	sightrangenight="0"
-	
-	buildingwalking="true"
+    sightrangeday="0"
+    sightrangenight="0"
+    
+    buildingwalking="true"
 
-	deathtime="0"
-	corpsetime="0"
+    deathtime="0"
+    corpsetime="0"
 
-	lifetime="6000"
+    lifetime="6000"
 
-	invulnerable="true"
-	hidealtinfo="true"
-	flying="true"
-	flyheight="150"
-	clearvision="true"
-	drawonmap="false"
-	
-	hazardradius="250"
+    invulnerable="true"
+    hidealtinfo="true"
+    flying="true"
+    flyheight="150"
+    clearvision="true"
+    drawonmap="false"
+    
+    hazardradius="250"
 
-	alwaystransmitdata="true"
-	
-	
-	
+    alwaystransmitdata="true"
 >
 
 
-	<onframe>
-		<lineofeffect
-			radius="120"
-			start="this_entity"
-			end="this_proxy_entity"
-			targetselection="all"
-			targetscheme="enemy_units_and_buildings"
-			effecttype="Magic"
-		>
-				<applystate name="State_Buford_Ability2_Burn" continuous="true" timeout="frametime" />
-		
-				
-			
-		</lineofeffect>
-	
-		<recordheroaggression  />
-				<aggression />
-	</onframe>
+    <onframe>
+        <lineofeffect
+            radius="120"
+            start="this_entity"
+            end="this_proxy_entity"
+            targetselection="all"
+            targetscheme="enemy_units_and_buildings"
+            effecttype="Magic"
+        >
+            <applystate name="State_Buford_Ability2_Burn" continuous="true" timeout="frametime" />
+        </lineofeffect>
+    </onframe>
 
 
 </gadget>

--- a/game/heroes/buford/ability_02/projectile.entity
+++ b/game/heroes/buford/ability_02/projectile.entity
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectile
+	name="Projectile_Buford_Ability2"
+
+	speed="2500"
+	gravity="150"
+
+	modelscale="1"
+	model="/shared/models/invis.mdf"
+	traileffect="effects/trail.effect"
+	
+	
+	canturn="false"
+	flying="true"
+	flyheight="10"
+	
+	impactdistance="25"
+
+	
+	lifetime="-1"
+>
+
+
+</projectile>

--- a/game/heroes/buford/ability_02/projectile.entity
+++ b/game/heroes/buford/ability_02/projectile.entity
@@ -1,24 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectile
-	name="Projectile_Buford_Ability2"
+    name="Projectile_Buford_Ability2"
 
-	speed="2500"
-	gravity="150"
+    speed="2500"
+    gravity="150"
 
-	modelscale="1"
-	model="/shared/models/invis.mdf"
-	traileffect="effects/trail.effect"
-	
-	
-	canturn="false"
-	flying="true"
-	flyheight="10"
-	
-	impactdistance="25"
-
-	
-	lifetime="-1"
+    modelscale="1"
+    model="/shared/models/invis.mdf"
+    traileffect="effects/trail.effect"
+    
+    
+    canturn="false"
+    flying="true"
+    flyheight="10"
+    
+    impactdistance="25"
+    
+    touchtargetscheme="enemy_heroes"
+    touchradius="120"
+    maxtouchespertarget="1"
+    
+    lifetime="-1"
 >
 
+    <ontouch>
+        <recordheroaggression  />
+        <aggression />
+    </ontouch>
 
 </projectile>

--- a/game/heroes/buford/ability_02/state_burn.entity
+++ b/game/heroes/buford/ability_02/state_burn.entity
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<state
+	name="State_Buford_Ability2_Burn"
+
+	icon="icon.tga"
+	passiveeffect="effects/state_enemy.effect"
+	ishidden="false"
+	
+	impactinterval="500"
+
+>
+
+	<onimpact>
+		<cantarget targetscheme="enemy_units" >
+		<pushability target="this_owner_entity" entity="tool_entity" name="Ability_Buford2" />
+		<getconstant name="damage" adjustmentsource="tool_entity" entity="stack_entity" />
+		<setvar0 a="result" b="2" op="div" />
+		<damage effecttype="Magic DOT" amount="1" b="var0" source="source_owner_entity" op="mult" />
+		</cantarget>
+		
+		<cantarget targetscheme="enemy_buildings" >
+		<pushability target="this_owner_entity" entity="tool_entity" name="Ability_Buford2" />
+		<getconstant name="damage" adjustmentsource="tool_entity" entity="stack_entity" />
+		<setvar0 a="result" b="2" op="div" />
+		<damage effecttype="Magic DOT" amount=".5" b="var0" source="source_owner_entity" op="mult" />
+		</cantarget>
+		<recordheroaggression source="source_owner_entity" />
+		<aggression source="source_owner_entity" />
+
+	</onimpact>
+	
+	
+
+</state>

--- a/game/heroes/buford/ability_02/state_burn.entity
+++ b/game/heroes/buford/ability_02/state_burn.entity
@@ -1,34 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <state
-	name="State_Buford_Ability2_Burn"
+    name="State_Buford_Ability2_Burn"
 
-	icon="icon.tga"
-	passiveeffect="effects/state_enemy.effect"
-	ishidden="false"
-	
-	impactinterval="500"
+    icon="icon.tga"
+    passiveeffect="effects/state_enemy.effect"
+    ishidden="false"
+    
+    impactinterval="500"
 
 >
 
-	<onimpact>
-		<cantarget targetscheme="enemy_units" >
-		<pushability target="this_owner_entity" entity="tool_entity" name="Ability_Buford2" />
-		<getconstant name="damage" adjustmentsource="tool_entity" entity="stack_entity" />
-		<setvar0 a="result" b="2" op="div" />
-		<damage effecttype="Magic DOT" amount="1" b="var0" source="source_owner_entity" op="mult" />
-		</cantarget>
-		
-		<cantarget targetscheme="enemy_buildings" >
-		<pushability target="this_owner_entity" entity="tool_entity" name="Ability_Buford2" />
-		<getconstant name="damage" adjustmentsource="tool_entity" entity="stack_entity" />
-		<setvar0 a="result" b="2" op="div" />
-		<damage effecttype="Magic DOT" amount=".5" b="var0" source="source_owner_entity" op="mult" />
-		</cantarget>
-		<recordheroaggression source="source_owner_entity" />
-		<aggression source="source_owner_entity" />
+    <onimpact>
+        <cantarget targetscheme="enemy_units" >
+        <pushability target="this_owner_entity" entity="tool_entity" name="Ability_Buford2" />
+        <getconstant name="damage" adjustmentsource="tool_entity" entity="stack_entity" />
+        <setvar0 a="result" b="2" op="div" />
+        <damage effecttype="Magic DOT" amount="1" b="var0" source="source_owner_entity" op="mult" />
+        </cantarget>
+        
+        <cantarget targetscheme="enemy_buildings" >
+        <pushability target="this_owner_entity" entity="tool_entity" name="Ability_Buford2" />
+        <getconstant name="damage" adjustmentsource="tool_entity" entity="stack_entity" />
+        <setvar0 a="result" b="2" op="div" />
+        <damage effecttype="Magic DOT" amount=".5" b="var0" source="source_owner_entity" op="mult" />
+        </cantarget>
 
-	</onimpact>
-	
-	
+    </onimpact>
 
 </state>


### PR DESCRIPTION
Buford's W no longer trigger tower and minion aggression when enemy hero steps in fire but triggers it if projectile creating fire hits enemy. This aligns with all other similar abilities.
Closes #182