### PR TITLE
Captain's Crest fixes

### DIFF
--- a/game/items/recipes/defensive/crusader_shield/state.entity
+++ b/game/items/recipes/defensive/crusader_shield/state.entity
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<state
+	name="State_CrusaderShield"
+
+	icon="icon.tga"
+	
+>
+
+	<onattackeddamageevent>
+		<cantarget targetscheme="enemy_towers" >
+			<setvalue name="damage_attempted" a="damage_attempted" b="0.8" op="mult" />
+		</cantarget>
+		<else>
+			<damageeffecttype effecttype="Splash">	
+				<setvalue name="damage_attempted" a="damage_attempted" b="0.6" op="mult" />
+			</damageeffecttype>
+		</else>
+	</onattackeddamageevent>
+
+</state>

--- a/game/items/recipes/defensive/crusader_shield/state.entity
+++ b/game/items/recipes/defensive/crusader_shield/state.entity
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <state
-	name="State_CrusaderShield"
+    name="State_CrusaderShield"
 
-	icon="icon.tga"
-	
+    icon="icon.tga"
+    
 >
 
-	<onattackeddamageevent>
-		<cantarget targetscheme="enemy_towers" >
-			<setvalue name="damage_attempted" a="damage_attempted" b="0.8" op="mult" />
-		</cantarget>
-		<else>
-			<damageeffecttype effecttype="Splash">	
-				<setvalue name="damage_attempted" a="damage_attempted" b="0.6" op="mult" />
-			</damageeffecttype>
-		</else>
-	</onattackeddamageevent>
+    <onattackeddamageevent>
+        <!-- Reducing damage from buildings -->
+        <targettype type="building">
+            <setvalue name="damage_attempted" a="damage_attempted" b="0.8" op="mult" />
+        </targettype>
+        <else>
+            <!-- Reducing splash damage -->
+            <damageeffecttype effecttype="Splash">	
+                <setvalue name="damage_attempted" a="damage_attempted" b="0.6" op="mult" />
+            </damageeffecttype>
+        </else>
+    </onattackeddamageevent>
 
 </state>

--- a/game/items/recipes/defensive/crusader_shield/state_empower_3.entity
+++ b/game/items/recipes/defensive/crusader_shield/state_empower_3.entity
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<state
+	name="State_CrusaderShield_Empower_3"
+
+	icon="icon.tga"
+>
+
+	<onattackeddamageevent>
+		<cantarget targetscheme="enemy_towers" >
+			<setvalue name="damage_attempted" a="damage_attempted" b="0.70" op="mult" />
+		</cantarget>
+	</onattackeddamageevent>
+
+</state>

--- a/game/items/recipes/defensive/crusader_shield/state_empower_3.entity
+++ b/game/items/recipes/defensive/crusader_shield/state_empower_3.entity
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <state
-	name="State_CrusaderShield_Empower_3"
+    name="State_CrusaderShield_Empower_3"
 
-	icon="icon.tga"
+    icon="icon.tga"
 >
 
-	<onattackeddamageevent>
-		<cantarget targetscheme="enemy_towers" >
-			<setvalue name="damage_attempted" a="damage_attempted" b="0.70" op="mult" />
-		</cantarget>
-	</onattackeddamageevent>
+    <onattackeddamageevent>
+        <targettype type="building">
+            <!-- Reducing damage. We already reduce damage by 20% in base item, so 80% left. 
+                 To make it 30% we need to take 87.5% from what is left 
+            -->
+            <setvalue name="damage_attempted" a="damage_attempted" b="0.875" op="mult" />
+        </targettype>
+    </onattackeddamageevent>
 
 </state>


### PR DESCRIPTION
Without this fix Captain's Crest reduce damage only from the first tower.
Also adjusted value for its Focus enchantment.