### PR TITLE
Healing rod rebalance

### DIFF
--- a/game/items/recipes/mana/healing scepter/empower_1.entity
+++ b/game/items/recipes/mana/healing scepter/empower_1.entity
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<qualityitem
+	name="Item_HealingScepter_Empower_1"
+	
+	cost="750"
+
+>
+	<!-- Tooltip only -->
+	<constant name="heal_enchant" value="150" qualityvalue="9.5" qualityadjustment="common" adjustment="power_support" op="add"/>
+	<constant name="mana_enchant" value="75" adjustment="none" qualityvalue="7.5" qualityadjustment="common" op="add"/>
+
+	<onimpact>
+		<compare a="target_entity" b="source_entity" op="ne" >
+			<playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
+		</compare>
+		
+		<getconstant name="heal_enchant" adjustmentsource="this_entity" />
+		<setvar0 a="result" b="1" op="mult" />
+		<heal a="var0" />
+		
+		<getconstant name="mana_enchant" op="add" />
+		<givemana amount="result" b="1" op="mult" />
+		<setcharges a="0" />
+	</onimpact>
+
+</qualityitem>

--- a/game/items/recipes/mana/healing scepter/empower_1.entity
+++ b/game/items/recipes/mana/healing scepter/empower_1.entity
@@ -20,8 +20,8 @@
         <heal a="result" />
         
         <!-- Give mana -->
-        <getconstant name="mana_enchant" />
-        <givemana amount="result"/>
+        <getconstant name="enchant_1_mana" />
+        <givemana target="target_entity" amount="result"/>
     </onimpact>
 
 </qualityitem>

--- a/game/items/recipes/mana/healing scepter/empower_1.entity
+++ b/game/items/recipes/mana/healing scepter/empower_1.entity
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <qualityitem
-	name="Item_HealingScepter_Empower_1"
-	
-	cost="750"
-
+    name="Item_HealingScepter_Empower_1"
+    
+    cost="550"
+    cooldowntime="45000"
 >
-	<!-- Tooltip only -->
-	<constant name="heal_enchant" value="150" qualityvalue="9.5" qualityadjustment="common" adjustment="power_support" op="add"/>
-	<constant name="mana_enchant" value="75" adjustment="none" qualityvalue="7.5" qualityadjustment="common" op="add"/>
+    <!-- Mana restored, adjusted by power -->
+    <constant name="enchant_1_mana" value="50" adjustment="none" />
+    <!-- TOOLTIP ONLY: item cooldown. Real value is above in cooldowntime attribute -->
+    <constant name="enchant_1_cd" value="45"  adjustment="none" />
 
-	<onimpact>
-		<compare a="target_entity" b="source_entity" op="ne" >
-			<playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
-		</compare>
-		
-		<getconstant name="heal_enchant" adjustmentsource="this_entity" />
-		<setvar0 a="result" b="1" op="mult" />
-		<heal a="var0" />
-		
-		<getconstant name="mana_enchant" op="add" />
-		<givemana amount="result" b="1" op="mult" />
-		<setcharges a="0" />
-	</onimpact>
+    <!-- When used: -->
+    <onimpact>
+        <!-- Play visual effect -->
+        <playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
+        
+        <!-- Heal target -->
+        <getconstant name="heal" adjustmentsource="this_entity" />
+        <heal a="result" />
+        
+        <!-- Give mana -->
+        <getconstant name="mana_enchant" />
+        <givemana amount="result"/>
+    </onimpact>
 
 </qualityitem>

--- a/game/items/recipes/mana/healing scepter/empower_2.entity
+++ b/game/items/recipes/mana/healing scepter/empower_2.entity
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<qualityitem
+	name="Item_HealingScepter_Empower_2"
+	
+	cost="700"
+	cooldowntime="25000"
+
+>
+
+</qualityitem>

--- a/game/items/recipes/mana/healing scepter/empower_2.entity
+++ b/game/items/recipes/mana/healing scepter/empower_2.entity
@@ -4,10 +4,11 @@
 
     cost="550"
     range="400"
+    hoverareacastrange="400"
 >
     <!-- Heal base value, adjusted by power -->
     <constant name="enchant_2_heal" value="160" adjustment="power_support" />
-    <!-- TOOLTIP ONLY:  -->
+    <!-- TOOLTIP ONLY: range decrease. Real range value is above -->
     <constant name="enchant_2_range" value="100" adjustment="none" />
 
     <!-- When used: -->

--- a/game/items/recipes/mana/healing scepter/empower_2.entity
+++ b/game/items/recipes/mana/healing scepter/empower_2.entity
@@ -1,10 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <qualityitem
-	name="Item_HealingScepter_Empower_2"
-	
-	cost="700"
-	cooldowntime="25000"
+    name="Item_HealingScepter_Empower_2"
 
+    cost="550"
+    range="400"
 >
+    <!-- Heal base value, adjusted by power -->
+    <constant name="enchant_2_heal" value="160" adjustment="power_support" />
+    <!-- TOOLTIP ONLY:  -->
+    <constant name="enchant_2_range" value="100" adjustment="none" />
+
+    <!-- When used: -->
+    <onimpact>
+        <!-- Play visual effect -->
+        <playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
+        
+        <!-- Heal target -->
+        <getconstant name="enchant_2_heal" adjustmentsource="this_entity" />
+        <heal a="result" />
+    </onimpact>
 
 </qualityitem>

--- a/game/items/recipes/mana/healing scepter/empower_3.entity
+++ b/game/items/recipes/mana/healing scepter/empower_3.entity
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<qualityitem
+	name="Item_HealingScepter_Empower_3"
+	
+	cost="650"
+
+>
+	<!-- Tooltip only -->
+	<constant name="areaheal_enchant" value="25" adjustment="none" qualityvalue="0" qualityadjustment="legendary" op="add" />
+
+	<onimpact>
+		<compare a="target_entity" b="source_entity" op="ne" >
+			<playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
+		</compare>
+		
+		<getconstant name="heal" adjustmentsource="this_entity" />
+		<setvar0 a="result" b="1" op="mult" />
+		<heal a="var0" />
+		
+		<getconstant name="mana" op="add" />
+		<setvar1 a="result" b="1" op="mult" />
+		<givemana amount="var1" b="1" op="mult" />
+		<setcharges a="0" />
+		
+		<areaofeffect
+			radius="600"
+			targetselection="all"
+			targetscheme="other_ally_units"
+			effecttype="Magic"
+		>
+			<getconstant name="heal" adjustmentsource="this_entity" />
+			<setvar0 a="result" b="1" op="mult" />
+			<heal a="var0" b="0.25" op="mult" />
+			
+			<getconstant name="mana" op="add" />
+			<setvar1 a="result" b="1" op="mult" />
+			<givemana amount="0.25" b="var1" op="mult" />
+		</areaofeffect>
+
+	</onimpact>
+
+</qualityitem>

--- a/game/items/recipes/mana/healing scepter/empower_3.entity
+++ b/game/items/recipes/mana/healing scepter/empower_3.entity
@@ -1,42 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <qualityitem
-	name="Item_HealingScepter_Empower_3"
-	
-	cost="650"
-
+    name="Item_HealingScepter_Empower_3"
+    
+    cost="550"
+    targetradius="300"
 >
-	<!-- Tooltip only -->
-	<constant name="areaheal_enchant" value="25" adjustment="none" qualityvalue="0" qualityadjustment="legendary" op="add" />
+    <!-- Tooltip only -->
+    <!-- Cooldown increase -->
+    <constant name="enchant_3_heal" value="100" adjustment="power_support" />
+    <!-- Ability area radius -->
+    <constant name="enchant_3_radius" value="300" adjustment="none" />
 
-	<onimpact>
-		<compare a="target_entity" b="source_entity" op="ne" >
-			<playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
-		</compare>
-		
-		<getconstant name="heal" adjustmentsource="this_entity" />
-		<setvar0 a="result" b="1" op="mult" />
-		<heal a="var0" />
-		
-		<getconstant name="mana" op="add" />
-		<setvar1 a="result" b="1" op="mult" />
-		<givemana amount="var1" b="1" op="mult" />
-		<setcharges a="0" />
-		
-		<areaofeffect
-			radius="600"
-			targetselection="all"
-			targetscheme="other_ally_units"
-			effecttype="Magic"
-		>
-			<getconstant name="heal" adjustmentsource="this_entity" />
-			<setvar0 a="result" b="1" op="mult" />
-			<heal a="var0" b="0.25" op="mult" />
-			
-			<getconstant name="mana" op="add" />
-			<setvar1 a="result" b="1" op="mult" />
-			<givemana amount="0.25" b="var1" op="mult" />
-		</areaofeffect>
+    <!-- When used: -->
+    <onimpact>
+        <!-- For every ally unit in radius -->
+        <areaofeffect
+            radius="300"
+            targetselection="all"
+            targetscheme="ally_units"
+            effecttype="Magic"
+        >
+            <!-- Play visual effect -->
+            <playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
+            <!-- Heal target -->
+            <getconstant name="enchant_3_heal" adjustmentsource="this_entity" />
+            <heal a="result" />
+        </areaofeffect>
 
-	</onimpact>
+    </onimpact>
 
 </qualityitem>

--- a/game/items/recipes/mana/healing scepter/empower_3.entity
+++ b/game/items/recipes/mana/healing scepter/empower_3.entity
@@ -3,19 +3,22 @@
     name="Item_HealingScepter_Empower_3"
     
     cost="550"
-    targetradius="300"
+    
+    targetradius="500"
+    targetmaterial="/shared/materials/area_cast_indicator_simple.material"
 >
     <!-- Tooltip only -->
     <!-- Cooldown increase -->
     <constant name="enchant_3_heal" value="100" adjustment="power_support" />
     <!-- Ability area radius -->
-    <constant name="enchant_3_radius" value="300" adjustment="none" />
+    <constant name="enchant_3_radius" value="600" adjustment="none" />
 
     <!-- When used: -->
     <onimpact>
         <!-- For every ally unit in radius -->
+        <getconstant name="enchant_3_radius" />
         <areaofeffect
-            radius="300"
+            radius="result"
             targetselection="all"
             targetscheme="ally_units"
             effecttype="Magic"
@@ -24,7 +27,7 @@
             <playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
             <!-- Heal target -->
             <getconstant name="enchant_3_heal" adjustmentsource="this_entity" />
-            <heal a="result" />
+            <heal a="result" target="target_entity" />
         </areaofeffect>
 
     </onimpact>

--- a/game/items/recipes/mana/healing scepter/item.entity
+++ b/game/items/recipes/mana/healing scepter/item.entity
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<crafteditem
+	name="Item_HealingScepter"
+	
+	icon="icon.tga"
+	
+	cost="550"
+	components="Item_Mender Item_Blade"
+	anim="item_self"
+	
+	actiontype="target_entity"
+	targetscheme="ally_units"
+	casttime="0"
+	castactiontime="0"
+	cooldowntime="30000"
+	casteffect="effects/cast.effect"
+	botitem="HealingScepterItem"
+	noentercombat="true"
+
+	showareacast="true"
+	areacastmaterial="/shared/materials/area_cast_indicator_spokes.material"
+	hoverareacastrange="500"
+	range="500"
+	
+	doubleactivate="true"
+	filters="defense,heal,activatable"
+
+	empoweredeffects="Item_HealingScepter_Empower_2,Item_HealingScepter_Empower_3"
+	
+	showinpractice="true"
+>
+	<constant name="heal" value="110" qualityvalue="11" qualityadjustment="common" adjustment="power_support" op="add"/>
+	<constant name="legendary" value="5" qualityvalue="5" qualityadjustment="legendary" adjustment="none" op="add" />
+	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+
+	
+	<onimpact>
+		<compare a="target_entity" b="source_entity" op="ne" >
+			<playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
+		</compare>
+		
+		<getconstant name="heal" adjustmentsource="this_entity" />
+		<setvar0 a="result" b="1" op="mult" />
+		<heal a="var0" />
+		
+	</onimpact>
+
+	<ondoubleactivate>
+		<useitem source="this_entity" target="source_entity" />
+	</ondoubleactivate>
+	
+</crafteditem>

--- a/game/items/recipes/mana/healing scepter/item.entity
+++ b/game/items/recipes/mana/healing scepter/item.entity
@@ -1,52 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <crafteditem
-	name="Item_HealingScepter"
-	
-	icon="icon.tga"
-	
-	cost="550"
-	components="Item_Mender Item_Blade"
-	anim="item_self"
-	
-	actiontype="target_entity"
-	targetscheme="ally_units"
-	casttime="0"
-	castactiontime="0"
-	cooldowntime="30000"
-	casteffect="effects/cast.effect"
-	botitem="HealingScepterItem"
-	noentercombat="true"
+    name="Item_HealingScepter"
+    
+    icon="icon.tga"
+    
+    cost="550"
+    components="Item_Mender Item_Blade"
+    anim="item_self"
+    
+    actiontype="target_entity"
+    targetscheme="ally_units"
+    casttime="0"
+    castactiontime="0"
+    cooldowntime="30000"
+    botitem="HealingScepterItem"
+    noentercombat="true"
 
-	showareacast="true"
-	areacastmaterial="/shared/materials/area_cast_indicator_spokes.material"
-	hoverareacastrange="500"
-	range="500"
-	
-	doubleactivate="true"
-	filters="defense,heal,activatable"
+    showareacast="true"
+    areacastmaterial="/shared/materials/area_cast_indicator_spokes.material"
+    hoverareacastrange="500"
+    range="500"
+    
+    doubleactivate="true"
+    filters="defense,heal,activatable"
 
-	empoweredeffects="Item_HealingScepter_Empower_2,Item_HealingScepter_Empower_3"
-	
-	showinpractice="true"
+    empoweredeffects="Item_HealingScepter_Empower_1,Item_HealingScepter_Empower_2,Item_HealingScepter_Empower_3"
+    
+    showinpractice="true"
 >
-	<constant name="heal" value="110" qualityvalue="11" qualityadjustment="common" adjustment="power_support" op="add"/>
-	<constant name="legendary" value="5" qualityvalue="5" qualityadjustment="legendary" adjustment="none" op="add" />
-	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+    <!-- Heal base value, adjusted by power -->
+    <constant name="heal" value="130" adjustment="power_support" />
 
-	
-	<onimpact>
-		<compare a="target_entity" b="source_entity" op="ne" >
-			<playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
-		</compare>
-		
-		<getconstant name="heal" adjustmentsource="this_entity" />
-		<setvar0 a="result" b="1" op="mult" />
-		<heal a="var0" />
-		
-	</onimpact>
+    <!-- When used: -->
+    <onimpact>
+        <!-- play visual effect -->
+        <playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
+        
+        <!-- Heal target -->
+        <getconstant name="heal" adjustmentsource="this_entity" />
+        <heal a="result" />
+    </onimpact>
 
-	<ondoubleactivate>
-		<useitem source="this_entity" target="source_entity" />
-	</ondoubleactivate>
-	
+    <!-- On double activation: use on self -->
+    <ondoubleactivate>
+        <useitem source="this_entity" target="source_entity" />
+    </ondoubleactivate>
+    
 </crafteditem>

--- a/game/items/recipes/mana/healing scepter/item.entity
+++ b/game/items/recipes/mana/healing scepter/item.entity
@@ -33,7 +33,7 @@
 
     <!-- When used: -->
     <onimpact>
-        <!-- play visual effect -->
+        <!-- Play visual effect -->
         <playeffect effect="effects/cast.effect" target="target_entity" source="target_entity" />
         
         <!-- Heal target -->

--- a/game/items/recipes/mana/healing scepter/item.entity
+++ b/game/items/recipes/mana/healing scepter/item.entity
@@ -6,7 +6,7 @@
     
     cost="550"
     components="Item_Mender Item_Blade"
-    anim="item_self"
+    anim="item_1"
     
     actiontype="target_entity"
     targetscheme="ally_units"

--- a/game/stringtables/entities_de.str
+++ b/game/stringtables/entities_de.str
@@ -2270,18 +2270,19 @@ Item_Lasthit_Empower_5_name											Die Jagd
 Item_Lasthit_Empower_5_description									Eine Einheit mit Axt werfen abzuschießen heilt dich für $heal_enchant$ Gesundheit.
 
 // Item_HealingScepter
+// Enchantments were updated, check entities_en.str!
 Item_HealingScepter_name											Heilstab
 Item_HealingScepter_description										^091Aktivieren: Heile das Ziel für^* ^o$heal$ Gesundheit^*^091.^*
 Item_HealingScepter_description_simple								^091Aktivieren: Gesundheit des Ziels wiederherstellen.^*
 Item_HealingScepter_bonusdescription								Erhöht die wiederhergestellte Gesundheit um $common_increase$%.
 Item_HealingScepter_legendaryname									Größer
 Item_HealingScepter_legendarydescription							Erhöht min. und max. Ladungen um $legendary$.
-Item_HealingScepter_Empower_1_name									Fokus
-Item_HealingScepter_Empower_1_description							Erhöht die Heilung auf ^o$heal_enchant$ Gesundheit^* und gibt $mana_enchant$ Mana. Die Abklingzeit verlängert sich um 50%.
-Item_HealingScepter_Empower_2_name									Sorgfalt
-Item_HealingScepter_Empower_2_description							Abklingzeit reduziert.
-Item_HealingScepter_Empower_3_name									Großzügigkeit
-Item_HealingScepter_Empower_3_description							Heilt auch umliegende Verbündete mit $areaheal_enchant$% Wirksamkeit
+//Item_HealingScepter_Empower_1_name									Fokus
+//Item_HealingScepter_Empower_1_description							Erhöht die Heilung auf ^o$heal_enchant$ Gesundheit^* und gibt $mana_enchant$ Mana. Die Abklingzeit verlängert sich um 50%.
+//Item_HealingScepter_Empower_2_name									Sorgfalt
+//Item_HealingScepter_Empower_2_description							Abklingzeit reduziert.
+//Item_HealingScepter_Empower_3_name									Großzügigkeit
+//Item_HealingScepter_Empower_3_description							Heilt auch umliegende Verbündete mit $areaheal_enchant$% Wirksamkeit
 
 // InfernoBrand
 Item_InfernoBrand_name												Teufelmarke

--- a/game/stringtables/entities_en.str
+++ b/game/stringtables/entities_en.str
@@ -2279,12 +2279,12 @@ Item_HealingScepter_description_simple							^091Activate: restore Health to tar
 Item_HealingScepter_bonusdescription							Increases the Health restored by $common_increase$%.
 Item_HealingScepter_legendaryname								Greater
 Item_HealingScepter_legendarydescription						Increases Min & Max charges by $legendary$.
-Item_HealingScepter_Empower_1_name								Focus
-Item_HealingScepter_Empower_1_description						Increases Heal to ^o$heal_enchant$ Health^* and gives $mana_enchant$ Mana. Cooldown becomes 50% longer.
-Item_HealingScepter_Empower_2_name								Diligence
-Item_HealingScepter_Empower_2_description						Cooldown reduced.
+Item_HealingScepter_Empower_1_name								Utility
+Item_HealingScepter_Empower_1_description						Also gives target $enchant_1_mana$ Mana. Cooldown increased to %enchant_1_cd% seconds.
+Item_HealingScepter_Empower_2_name								Focus
+Item_HealingScepter_Empower_2_description						Increases Heal to ^o$heal_enchant$ Health^*, but range is decreased by $enchant_2_range$.
 Item_HealingScepter_Empower_3_name								Generosity
-Item_HealingScepter_Empower_3_description						Also heals nearby allies for $areaheal_enchant$% effectiveness.
+Item_HealingScepter_Empower_3_description						Decreases heal to ^o$enchant_3_heal$ Health^* but also heals allies in $enchant_3_radius$ radius around target.
 
 // InfernoBrand
 Item_InfernoBrand_name											Inferno Brand

--- a/game/stringtables/entities_en.str
+++ b/game/stringtables/entities_en.str
@@ -2280,9 +2280,9 @@ Item_HealingScepter_bonusdescription							Increases the Health restored by $com
 Item_HealingScepter_legendaryname								Greater
 Item_HealingScepter_legendarydescription						Increases Min & Max charges by $legendary$.
 Item_HealingScepter_Empower_1_name								Utility
-Item_HealingScepter_Empower_1_description						Also gives target $enchant_1_mana$ Mana. Cooldown increased to %enchant_1_cd% seconds.
+Item_HealingScepter_Empower_1_description						Also gives target $enchant_1_mana$ Mana. Cooldown increased to $enchant_1_cd$ seconds.
 Item_HealingScepter_Empower_2_name								Focus
-Item_HealingScepter_Empower_2_description						Increases Heal to ^o$heal_enchant$ Health^*, but range is decreased by $enchant_2_range$.
+Item_HealingScepter_Empower_2_description						Increases Heal to ^o$enchant_2_heal$ Health^*, but range is decreased by $enchant_2_range$.
 Item_HealingScepter_Empower_3_name								Generosity
 Item_HealingScepter_Empower_3_description						Decreases heal to ^o$enchant_3_heal$ Health^* but also heals allies in $enchant_3_radius$ radius around target.
 

--- a/game/stringtables/entities_es.str
+++ b/game/stringtables/entities_es.str
@@ -1946,18 +1946,19 @@ Item_Lasthit_Empower_5_name                                                  La 
 Item_Lasthit_Empower_5_description                                           Matar una unidad con el hacha arrojadiza te cura $heal_enchant$ de salud.
 
 // Item_HealingScepter
+// Enchantments were updated, check entities_en.str!
 Item_HealingScepter_name                                                     Varilla de Curación
 Item_HealingScepter_description                                              Activa para curar hasta ^o$heal$ de salud^* (sube con el poder) y restaurar hasta $mana$ de mana, en base a un número cargas acumuladas.
 Item_HealingScepter_description_simple                                       Activa para restaurar salud y mana.
 Item_HealingScepter_bonusdescription                                         Aumenta la salud y el mana restaurados en un $common_increase$%.
 Item_HealingScepter_legendaryname                                            Mayor
 Item_HealingScepter_legendarydescription                                     Aumenta las cargas mín. y máx. por $legendary$.
-Item_HealingScepter_Empower_1_name                                           Poder 1
-Item_HealingScepter_Empower_1_description                                    Aumenta la curación máx. a ^o$heal_enchant$ de salud^* y $mana_enchant$ de mana. El tiempo de recarga aumenta un 50%.
-Item_HealingScepter_Empower_2_name                                           Diligencia
-Item_HealingScepter_Empower_2_description                                    Almacena cargas un 33% más rápido.
-Item_HealingScepter_Empower_3_name                                           Generosidad
-Item_HealingScepter_Empower_3_description                                    También cura a los aliados cercanos con un $areaheal_enchant$% de efectividad.
+//Item_HealingScepter_Empower_1_name                                           Poder 1
+//Item_HealingScepter_Empower_1_description                                    Aumenta la curación máx. a ^o$heal_enchant$ de salud^* y $mana_enchant$ de mana. El tiempo de recarga aumenta un 50%.
+//Item_HealingScepter_Empower_2_name                                           Diligencia
+//Item_HealingScepter_Empower_2_description                                    Almacena cargas un 33% más rápido.
+//Item_HealingScepter_Empower_3_name                                           Generosidad
+//Item_HealingScepter_Empower_3_description                                    También cura a los aliados cercanos con un $areaheal_enchant$% de efectividad.
 
 // InfernoBrand
 Item_InfernoBrand_name                                                       Marca del Infierno

--- a/game/stringtables/entities_fr.str
+++ b/game/stringtables/entities_fr.str
@@ -1948,18 +1948,19 @@ Item_Lasthit_Empower_5_name                                                     
 Item_Lasthit_Empower_5_description                                                Éliminer une unité avec Lancer de la Hache vous restitue $heal_enchant$ PV.
 
 // Item_HealingScepter
+// Enchantments were updated, check entities_en.str!
 Item_HealingScepter_name                                                          Sceptre de Guérison
 Item_HealingScepter_description                                                   Activez ceci pour régénérer ^o$heal$ PV^* (proportionnellement à la Puissance) et restaurer jusqu'à $mana$ Mana, selon le nombre de charges accumulées.
 Item_HealingScepter_description_simple                                            Activez ceci pour restaurer les PV et le Mana.
 Item_HealingScepter_bonusdescription                                              Augmente les PV et le Mana restaurés de $common_increase$ %.
 Item_HealingScepter_legendaryname                                                 Meilleur
 Item_HealingScepter_legendarydescription                                          Augmente le nombre de charges minimal et maximal de $legendary$.
-Item_HealingScepter_Empower_1_name                                                Puissance 1
-Item_HealingScepter_Empower_1_description                                         Augmente la guérison maximale pour atteindre ^o$heal_enchant$ PV^* et $mana_enchant$ Mana. Le délai de rechargement devient 50 % plus long.
-Item_HealingScepter_Empower_2_name                                                Zèle
-Item_HealingScepter_Empower_2_description                                         Accumule les charges 33 % plus rapidement.
-Item_HealingScepter_Empower_3_name                                                Générosité
-Item_HealingScepter_Empower_3_description                                         Guérit aussi les alliés à proximité avec une efficacité de $areaheal_enchant$ %.
+//Item_HealingScepter_Empower_1_name                                                Puissance 1
+//Item_HealingScepter_Empower_1_description                                         Augmente la guérison maximale pour atteindre ^o$heal_enchant$ PV^* et $mana_enchant$ Mana. Le délai de rechargement devient 50 % plus long.
+//Item_HealingScepter_Empower_2_name                                                Zèle
+//Item_HealingScepter_Empower_2_description                                         Accumule les charges 33 % plus rapidement.
+//Item_HealingScepter_Empower_3_name                                                Générosité
+//Item_HealingScepter_Empower_3_description                                         Guérit aussi les alliés à proximité avec une efficacité de $areaheal_enchant$ %.
 
 // InfernoBrand
 Item_InfernoBrand_name                                                            Marque des Enfers

--- a/game/stringtables/entities_pt_br.str
+++ b/game/stringtables/entities_pt_br.str
@@ -2152,18 +2152,19 @@ Item_Lasthit_Empower_5_name										A caçada
 Item_Lasthit_Empower_5_description								Matar uma unidade com o machado de arremesso cura $heal_enchant$ de vida.
 
 // Item_HealingScepter
+// Enchantments were updated, check entities_en.str!
 Item_HealingScepter_name										Bastão de cura
 Item_HealingScepter_description									Ative para curar até ^o$heal$ de vida^* (escalonado com poder) e restaurar até $mana$ de mana com base no número de cargas acumuladas.
 Item_HealingScepter_description_simple							Ative para restaurar vida e mana.
 Item_HealingScepter_bonusdescription							Aumenta a vida e o mana restaurados em $common_increase$%.
 Item_HealingScepter_legendaryname								Maior
 Item_HealingScepter_legendarydescription						Aumenta o mínimo e o máximo de cargas em $legendary$.
-Item_HealingScepter_Empower_1_name								Fortificar 1
-Item_HealingScepter_Empower_1_description						Aumenta o mínimo e o máximo de cargas em $charges_enchant$.
-Item_HealingScepter_Empower_2_name								Diligência
-Item_HealingScepter_Empower_2_description						Armazena cargas 33% mais rápido.
-Item_HealingScepter_Empower_3_name								Generosidade
-Item_HealingScepter_Empower_3_description						Também cura aliados próximos em $areaheal_enchant$% de efetividade.
+//Item_HealingScepter_Empower_1_name								Fortificar 1
+//Item_HealingScepter_Empower_1_description						Aumenta o mínimo e o máximo de cargas em $charges_enchant$.
+//Item_HealingScepter_Empower_2_name								Diligência
+//Item_HealingScepter_Empower_2_description						Armazena cargas 33% mais rápido.
+//Item_HealingScepter_Empower_3_name								Generosidade
+//Item_HealingScepter_Empower_3_description						Também cura aliados próximos em $areaheal_enchant$% de efetividade.
 
 // InfernoBrand
 Item_InfernoBrand_name											Tição infernal

--- a/game/stringtables/entities_ru.str
+++ b/game/stringtables/entities_ru.str
@@ -2468,17 +2468,17 @@ Item_Lasthit_Empower_5_description								Если вы убиваете бой�
 
 // Item_HealingScepter
 Item_HealingScepter_name										Healing Rod
-Item_HealingScepter_description									Примените, чтобы восстановить ^o$heal$ здоровья^*.
+Item_HealingScepter_description									Примените, чтобы восстановить цели ^o$heal$ здоровья^*.
 Item_HealingScepter_description_simple							При использовании восстанавливает здоровье.
 Item_HealingScepter_bonusdescription							Количество восстанавливаемого здоровья увеличено на $common_increase$%.
 Item_HealingScepter_legendaryname								Greater
 Item_HealingScepter_legendarydescription						Минимальное и максимальное количество зарядов увеличено на $legendary$.
-Item_HealingScepter_Empower_1_name								Focus
-Item_HealingScepter_Empower_1_description						Усиливает лечение на ^o$heal_enchant$^* и увеличивает максимальный запас маны на $mana_enchant$. Увеличивает время перезарядки на 50%.
-Item_HealingScepter_Empower_2_name								Diligence
-Item_HealingScepter_Empower_2_description						Уменьшает время перезарядки.
+Item_HealingScepter_Empower_1_name								Utility
+Item_HealingScepter_Empower_1_description						Дополнительно восстанавливает цели $enchant_1_mana$ маны. Время перезарядки увеличено до $enchant_1_cd$ секунд.
+Item_HealingScepter_Empower_2_name								Focus
+Item_HealingScepter_Empower_2_description						Восстанавливает ^o$enchant_2_heal$ здоровья^*, но дальность применения уменьшена на $enchant_2_range$.
 Item_HealingScepter_Empower_3_name								Generosity
-Item_HealingScepter_Empower_3_description						Исцеляет находящихся рядом союзников на $areaheal_enchant$% от количества восстановленного герою здоровья.
+Item_HealingScepter_Empower_3_description						Восстанавливает ^o$enchant_3_heal$ здоровья^*, но также исцеляет союзников в радиусе $enchant_3_radius$ вокруг цели.
 
 // InfernoBrand
 Item_InfernoBrand_name											Inferno Brand

--- a/game/stringtables/entities_th.str
+++ b/game/stringtables/entities_th.str
@@ -2183,18 +2183,19 @@ Item_Lasthit_Empower_5_name										The Hunt
 Item_Lasthit_Empower_5_description								ฆ่ายูนิตด้วย Throwing Axe จะฟื้นฟูพลังชีวิต $heal_enchant$
 
 // Item_HealingScepter
+// Enchantments were updated, check entities_en.str!
 Item_HealingScepter_name										Healing Rod
 Item_HealingScepter_description									กดใช้เพื่อฟื้นฟู^oพลังชีวิต $heal$^*(คิดจาก Power)  และมานา $mana$ จำนวนการฟื้นฟูนั้นขึ้นอยู่กับการสะสมชาร์จ
 Item_HealingScepter_description_simple							กดใช้งานเพื่อทำการฟื้นฟูพลังชีวิตและมานา
 Item_HealingScepter_bonusdescription							เพิ่มจำนวนการฟื้นฟูพลังชีวิตและมานา $common_increase$%
 Item_HealingScepter_legendaryname								Greater
 Item_HealingScepter_legendarydescription						เพิ่มจำนวนชาร์จขั้นต่ำและสูงสุด  $legendary$
-Item_HealingScepter_Empower_1_name								Focus
-Item_HealingScepter_Empower_1_description						เพิ่มการฮีลสูงสุงเป็น $charges_enchant$ และ $mana_enchant$ มานา คูลดาวน์เพิ่มขึ้น 50%
-Item_HealingScepter_Empower_2_name								Diligence
-Item_HealingScepter_Empower_2_description						เก็บชาร์จเร็วขึ้น 33%
-Item_HealingScepter_Empower_3_name								Generosity
-Item_HealingScepter_Empower_3_description						ฮีลให้เพื่อนร่วมทีม $areaheal_enchant$%
+//Item_HealingScepter_Empower_1_name								Focus
+//Item_HealingScepter_Empower_1_description						เพิ่มการฮีลสูงสุงเป็น $charges_enchant$ และ $mana_enchant$ มานา คูลดาวน์เพิ่มขึ้น 50%
+//Item_HealingScepter_Empower_2_name								Diligence
+//Item_HealingScepter_Empower_2_description						เก็บชาร์จเร็วขึ้น 33%
+//Item_HealingScepter_Empower_3_name								Generosity
+//Item_HealingScepter_Empower_3_description						ฮีลให้เพื่อนร่วมทีม $areaheal_enchant$%
 
 // InfernoBrand
 Item_InfernoBrand_name											Inferno Brand

--- a/game/stringtables/entities_vi.str
+++ b/game/stringtables/entities_vi.str
@@ -2017,18 +2017,19 @@ Item_Lasthit_Empower_5_name										The Hunt
 Item_Lasthit_Empower_5_description								Dùng item, ném búa giết lính, hồi phục $heal_enchant$ HP.
 
 // Item_HealingScepter
+// Enchantments were updated, check entities_en.str!
 Item_HealingScepter_name										Healing Rod
 Item_HealingScepter_description									Kích hoạt để hồi phục ^o$heal$ HP^* (dựa trên power) và hồi phục $mana$ mana, nhiều hay ít dựa trên số lượng tích trữ.
 Item_HealingScepter_description_simple							Kích hoạt để hồi phục HP và Mana.
 Item_HealingScepter_bonusdescription							Tăng HP và MP hồi phục $common_increase$%.
 Item_HealingScepter_legendaryname								Greater
 Item_HealingScepter_legendarydescription						Tăng Min & Max số lần tích trữ thêm $legendary$.
-Item_HealingScepter_Empower_1_name								Empower 1
-Item_HealingScepter_Empower_1_description						Tăng Min & Max số lần tích trữ thêm $charges_enchant$.
-Item_HealingScepter_Empower_2_name								Diligence
-Item_HealingScepter_Empower_2_description						Tăng 33% tốc độ lưu trữ.
-Item_HealingScepter_Empower_3_name								Generosity
-Item_HealingScepter_Empower_3_description						Hồi phục cho đồng đội với $areaheal_enchant$% hiểu quả.
+//Item_HealingScepter_Empower_1_name								Empower 1
+//Item_HealingScepter_Empower_1_description						Tăng Min & Max số lần tích trữ thêm $charges_enchant$.
+//Item_HealingScepter_Empower_2_name								Diligence
+//Item_HealingScepter_Empower_2_description						Tăng 33% tốc độ lưu trữ.
+//Item_HealingScepter_Empower_3_name								Generosity
+//Item_HealingScepter_Empower_3_description						Hồi phục cho đồng đội với $areaheal_enchant$% hiểu quả.
 
 // InfernoBrand
 Item_InfernoBrand_name											Inferno Brand

--- a/game/stringtables/entities_zh.str
+++ b/game/stringtables/entities_zh.str
@@ -2298,18 +2298,19 @@ Item_Lasthit_Empower_5_name										5
 Item_Lasthit_Empower_5_description								用飞斧击杀一个敌方单位会为英雄提供$heal_enchant$生命回复。
 
 // Item_HealingScepter
+// Enchantments were updated, check entities_en.str!
 Item_HealingScepter_name												愈合权杖
 Item_HealingScepter_description									^使用: 为目标提供^* ^o$heal$生命值^*的治疗。^0积攒最多$mana$法力。^* 
 Item_HealingScepter_description_simple											使用后立即回复生命值和法力值。
 Item_HealingScepter_bonusdescription												+$common_increase$%回复的生命和法力值
 Item_HealingScepter_legendaryname												卓越
 Item_HealingScepter_legendarydescription												增加$legendary$最小&最大充能数。 
-Item_HealingScepter_Empower_1_name								专注
-Item_HealingScepter_Empower_1_description						增加最大治疗效力，以提供^o$heal_enchant$生命值^*和$mana_enchant$法力值。冷却时间减少一半。 
-Item_HealingScepter_Empower_2_name								勤奋
-Item_HealingScepter_Empower_2_description						储存充能时速度加快33%。 
-Item_HealingScepter_Empower_3_name								慷慨
-Item_HealingScepter_Empower_3_description						为周围盟友提供$areaheal_enchant$%治疗。
+//Item_HealingScepter_Empower_1_name								专注
+//Item_HealingScepter_Empower_1_description						增加最大治疗效力，以提供^o$heal_enchant$生命值^*和$mana_enchant$法力值。冷却时间减少一半。 
+//Item_HealingScepter_Empower_2_name								勤奋
+//Item_HealingScepter_Empower_2_description						储存充能时速度加快33%。 
+//Item_HealingScepter_Empower_3_name								慷慨
+//Item_HealingScepter_Empower_3_description						为周围盟友提供$areaheal_enchant$%治疗。
 
 // InfernoBrand
 Item_InfernoBrand_name												地狱火徽记


### PR DESCRIPTION
Healing rod rebalance:
- Base Item: Health healed increased 100->130;
- Enchantments reworked: all cost 0 additional gold.
  - Utility: Also gives target 50 Mana. Cooldown increased by 15 seconds;
  - Focus: Increases Heal to 30 Health, but range is decreased by 100;
  - Generosity: Decreases heal to 100 Health but also heals allies in 600 radius around target.

Also fixed visual effect, cleared unused code, added comments.