### PR TITLE
Attack damage rebalance

### DIFF
--- a/game/items/recipes/damage/dark_bargain/empower_2.entity
+++ b/game/items/recipes/damage/dark_bargain/empower_2.entity
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<qualityitem
+	name="Item_Dark_Bargain_Empower_2"
+	
+	cost="2000"
+	
+	basedamagepercharge="8"
+
+	
+>
+	<constant name="perm_bonus" value="2" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
+	<constant name="bonus" value="8" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
+	<constant name="gold_enchant" value="250" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
+	
+	<onimpact>
+		<getconstant name="gold_enchant" adjustmentsource="none" />
+		<compare a="target_gold" b="result" op="ge" >
+			<spendgold amount="250" position="source_entity" />
+				<addcharges count="1" />
+				<applystate name="State_Bargain_Timer" duration="8000" proxy="this_entity" />
+				<applystate name="State_Bargain_Permanent_Empower_2" continuous="true" proxy="this_entity" />
+				<starttimer duration="8000" />
+				<popup name="dark_bargain" source="source_entity" target="source_entity" />
+		</compare>
+	</onimpact>
+</qualityitem>

--- a/game/items/recipes/damage/dark_bargain/empower_2.entity
+++ b/game/items/recipes/damage/dark_bargain/empower_2.entity
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <qualityitem
-	name="Item_Dark_Bargain_Empower_2"
-	
-	cost="2000"
-	
-	basedamagepercharge="8"
+    name="Item_Dark_Bargain_Empower_2"
+    
+    cost="2000"
+    
+    basedamagepercharge="9"
 
-	
+    
 >
-	<constant name="perm_bonus" value="2" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
-	<constant name="bonus" value="8" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
-	<constant name="gold_enchant" value="250" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
-	
-	<onimpact>
-		<getconstant name="gold_enchant" adjustmentsource="none" />
-		<compare a="target_gold" b="result" op="ge" >
-			<spendgold amount="250" position="source_entity" />
-				<addcharges count="1" />
-				<applystate name="State_Bargain_Timer" duration="8000" proxy="this_entity" />
-				<applystate name="State_Bargain_Permanent_Empower_2" continuous="true" proxy="this_entity" />
-				<starttimer duration="8000" />
-				<popup name="dark_bargain" source="source_entity" target="source_entity" />
-		</compare>
-	</onimpact>
+    <constant name="perm_bonus" value="3" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
+    <constant name="bonus" value="9" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
+    <constant name="gold_enchant" value="250" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
+    
+    <onimpact>
+        <getconstant name="gold_enchant" adjustmentsource="none" />
+        <compare a="target_gold" b="result" op="ge" >
+            <spendgold amount="250" position="source_entity" />
+            <addcharges count="1" />
+            <applystate name="State_Bargain_Timer" duration="8000" proxy="this_entity" />
+            <applystate name="State_Bargain_Permanent_Empower_2" continuous="true" proxy="this_entity" />
+            <starttimer duration="8000" />
+            <popup name="dark_bargain" source="source_entity" target="source_entity" />
+        </compare>
+    </onimpact>
 </qualityitem>

--- a/game/items/recipes/damage/dark_bargain/item.entity
+++ b/game/items/recipes/damage/dark_bargain/item.entity
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<crafteditem
+	name="Item_Dark_Bargain"
+
+	icon="icon.tga"
+	
+	cost="2000"
+	components="Item_Warpcleft Item_GlovesOfHaste Item_Staff"
+	anim="item_self"
+	
+	actiontype="target_self"
+	cooldowntime="0"
+	
+	maxcharges="50"
+
+	queue="front"
+	inheritmovement="true"
+
+	botitem="DarkBargainItem"
+	filters="activatable,attack,attack_damage"
+	alwaysshowtimer="true"
+
+	basedamage="40"
+	basedamagepercharge="20"
+
+	empoweredeffects="Item_Dark_Bargain_Empower_1,Item_Dark_Bargain_Empower_2"
+	
+	showinpractice="true"
+>
+
+	<!--Tooltip Only-->
+	<constant name="damage" value="40" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
+	<constant name="bonus" value="20" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
+	<constant name="perm_bonus" value="5" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
+	<constant name="gold" value="500" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
+	
+	<onimpact>
+		<getconstant name="gold" adjustmentsource="none" />
+		<compare a="target_gold" b="result" op="ge" >
+			<spendgold amount="500" position="source_entity" />
+				<addcharges count="1" />
+				<applystate name="State_Bargain_Timer" duration="8000" proxy="this_entity" />
+				<applystate name="State_Bargain_Permanent" continuous="true" proxy="this_entity" />
+      <playeffect effect="effects/sound.effect" source="source_entity" target="" occlude="true" />
+      <starttimer duration="8000" />
+				<popup name="dark_bargain" source="source_entity" target="source_entity" />
+		</compare>
+	</onimpact>
+
+</crafteditem>

--- a/game/items/recipes/damage/dark_bargain/item.entity
+++ b/game/items/recipes/damage/dark_bargain/item.entity
@@ -20,7 +20,7 @@
     filters="activatable,attack,attack_damage"
     alwaysshowtimer="true"
 
-    basedamage="48"
+    basedamage="46"
     basedamagepercharge="20"
 
     empoweredeffects="Item_Dark_Bargain_Empower_1,Item_Dark_Bargain_Empower_2"
@@ -29,7 +29,7 @@
 >
 
     <!--Tooltip Only-->
-    <constant name="damage" value="48" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
+    <constant name="damage" value="46" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
     <constant name="bonus" value="20" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
     <constant name="perm_bonus" value="5" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
     <constant name="gold" value="500" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>

--- a/game/items/recipes/damage/dark_bargain/item.entity
+++ b/game/items/recipes/damage/dark_bargain/item.entity
@@ -1,50 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <crafteditem
-	name="Item_Dark_Bargain"
+    name="Item_Dark_Bargain"
 
-	icon="icon.tga"
-	
-	cost="2000"
-	components="Item_Warpcleft Item_GlovesOfHaste Item_Staff"
-	anim="item_self"
-	
-	actiontype="target_self"
-	cooldowntime="0"
-	
-	maxcharges="50"
+    icon="icon.tga"
+    
+    cost="2000"
+    components="Item_Warpcleft Item_GlovesOfHaste Item_Staff"
+    anim="item_self"
+    
+    actiontype="target_self"
+    cooldowntime="0"
+    
+    maxcharges="50"
 
-	queue="front"
-	inheritmovement="true"
+    queue="front"
+    inheritmovement="true"
 
-	botitem="DarkBargainItem"
-	filters="activatable,attack,attack_damage"
-	alwaysshowtimer="true"
+    botitem="DarkBargainItem"
+    filters="activatable,attack,attack_damage"
+    alwaysshowtimer="true"
 
-	basedamage="40"
-	basedamagepercharge="20"
+    basedamage="48"
+    basedamagepercharge="20"
 
-	empoweredeffects="Item_Dark_Bargain_Empower_1,Item_Dark_Bargain_Empower_2"
-	
-	showinpractice="true"
+    empoweredeffects="Item_Dark_Bargain_Empower_1,Item_Dark_Bargain_Empower_2"
+    
+    showinpractice="true"
 >
 
-	<!--Tooltip Only-->
-	<constant name="damage" value="40" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
-	<constant name="bonus" value="20" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
-	<constant name="perm_bonus" value="5" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
-	<constant name="gold" value="500" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
-	
-	<onimpact>
-		<getconstant name="gold" adjustmentsource="none" />
-		<compare a="target_gold" b="result" op="ge" >
-			<spendgold amount="500" position="source_entity" />
-				<addcharges count="1" />
-				<applystate name="State_Bargain_Timer" duration="8000" proxy="this_entity" />
-				<applystate name="State_Bargain_Permanent" continuous="true" proxy="this_entity" />
+    <!--Tooltip Only-->
+    <constant name="damage" value="48" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
+    <constant name="bonus" value="20" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
+    <constant name="perm_bonus" value="5" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
+    <constant name="gold" value="500" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
+    
+    <onimpact>
+        <getconstant name="gold" adjustmentsource="none" />
+        <compare a="target_gold" b="result" op="ge" >
+            <spendgold amount="500" position="source_entity" />
+                <addcharges count="1" />
+                <applystate name="State_Bargain_Timer" duration="8000" proxy="this_entity" />
+                <applystate name="State_Bargain_Permanent" continuous="true" proxy="this_entity" />
       <playeffect effect="effects/sound.effect" source="source_entity" target="" occlude="true" />
       <starttimer duration="8000" />
-				<popup name="dark_bargain" source="source_entity" target="source_entity" />
-		</compare>
-	</onimpact>
+                <popup name="dark_bargain" source="source_entity" target="source_entity" />
+        </compare>
+    </onimpact>
 
 </crafteditem>

--- a/game/items/recipes/damage/dark_bargain/item.entity
+++ b/game/items/recipes/damage/dark_bargain/item.entity
@@ -21,7 +21,7 @@
     alwaysshowtimer="true"
 
     basedamage="46"
-    basedamagepercharge="20"
+    basedamagepercharge="23"
 
     empoweredeffects="Item_Dark_Bargain_Empower_1,Item_Dark_Bargain_Empower_2"
     
@@ -30,20 +30,20 @@
 
     <!--Tooltip Only-->
     <constant name="damage" value="46" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
-    <constant name="bonus" value="20" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
-    <constant name="perm_bonus" value="5" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
+    <constant name="bonus" value="23" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
+    <constant name="perm_bonus" value="6" adjustment="item" qualityvalue="0" qualityadjustment="common" op="add"/>
     <constant name="gold" value="500" adjustment="none" qualityvalue="0" qualityadjustment="common" op="add"/>
     
     <onimpact>
         <getconstant name="gold" adjustmentsource="none" />
         <compare a="target_gold" b="result" op="ge" >
             <spendgold amount="500" position="source_entity" />
-                <addcharges count="1" />
-                <applystate name="State_Bargain_Timer" duration="8000" proxy="this_entity" />
-                <applystate name="State_Bargain_Permanent" continuous="true" proxy="this_entity" />
-      <playeffect effect="effects/sound.effect" source="source_entity" target="" occlude="true" />
-      <starttimer duration="8000" />
-                <popup name="dark_bargain" source="source_entity" target="source_entity" />
+            <addcharges count="1" />
+            <applystate name="State_Bargain_Timer" duration="8000" proxy="this_entity" />
+            <applystate name="State_Bargain_Permanent" continuous="true" proxy="this_entity" />
+            <playeffect effect="effects/sound.effect" source="source_entity" target="" occlude="true" />
+            <starttimer duration="8000" />
+            <popup name="dark_bargain" source="source_entity" target="source_entity" />
         </compare>
     </onimpact>
 

--- a/game/items/recipes/damage/dark_bargain/state_permanent.entity
+++ b/game/items/recipes/damage/dark_bargain/state_permanent.entity
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<state
+    name="State_Bargain_Permanent" 
+
+    icon="icon.tga" 
+
+    effecttype="" 
+    deathpersist="true"
+	basedamagepercharge="5"
+    ishidden="true"
+
+>
+    <oninflict>
+        <setcharges a="0" />
+        <addcharges count="1" />
+    </oninflict>
+
+    <onrefresh>
+        <addcharges count="1" />
+    </onrefresh>
+</state>

--- a/game/items/recipes/damage/dark_bargain/state_permanent.entity
+++ b/game/items/recipes/damage/dark_bargain/state_permanent.entity
@@ -6,7 +6,7 @@
 
     effecttype="" 
     deathpersist="true"
-	basedamagepercharge="5"
+    basedamagepercharge="6"
     ishidden="true"
 
 >

--- a/game/items/recipes/damage/dark_bargain/state_permanent_empower_2.entity
+++ b/game/items/recipes/damage/dark_bargain/state_permanent_empower_2.entity
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<state
+    name="State_Bargain_Permanent_Empower_2" 
+
+    icon="icon.tga" 
+
+    effecttype="" 
+    deathpersist="true"
+	basedamagepercharge="2"
+    ishidden="true"
+
+>
+    <oninflict>
+        <setcharges a="0" />
+        <addcharges count="1" />
+    </oninflict>
+
+    <onrefresh>
+        <addcharges count="1" />
+    </onrefresh>
+</state>

--- a/game/items/recipes/damage/dark_bargain/state_permanent_empower_2.entity
+++ b/game/items/recipes/damage/dark_bargain/state_permanent_empower_2.entity
@@ -6,7 +6,7 @@
 
     effecttype="" 
     deathpersist="true"
-	basedamagepercharge="2"
+    basedamagepercharge="3"
     ishidden="true"
 
 >

--- a/game/items/recipes/damage/demon_edge/empower_3.entity
+++ b/game/items/recipes/damage/demon_edge/empower_3.entity
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<qualityitem
+	name="Item_DemonEdge_Empower_3"
+	
+	cost="1255"
+	basedamage="23"
+
+>
+	<!-- Tooltip only -->
+	<constant name="damage_enchant" value="5" adjustment="none" qualityvalue="0" qualityadjustment="legendary" op="add" />
+
+</qualityitem>

--- a/game/items/recipes/damage/demon_edge/empower_3.entity
+++ b/game/items/recipes/damage/demon_edge/empower_3.entity
@@ -3,10 +3,10 @@
 	name="Item_DemonEdge_Empower_3"
 	
 	cost="1255"
-	basedamage="23"
+	basedamage="27"
 
 >
 	<!-- Tooltip only -->
-	<constant name="damage_enchant" value="5" adjustment="none" qualityvalue="0" qualityadjustment="legendary" op="add" />
+	<constant name="damage_enchant" value="6" adjustment="none" qualityvalue="0" qualityadjustment="legendary" op="add" />
 
 </qualityitem>

--- a/game/items/recipes/damage/demon_edge/item.entity
+++ b/game/items/recipes/damage/demon_edge/item.entity
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<crafteditem
+	name="Item_DemonEdge"
+	
+	icon="icon.tga"
+	
+	cost="900"
+	components="Item_Blade Item_Blade Item_GlovesOfHaste"
+	craftingmaxcomponents="3"
+	
+	
+	actiontype="passive"
+	basedamage="18"
+	basedamageperquality="1.8"
+
+
+
+	filters="attack_damage,attack"
+
+	empoweredeffects="Item_DemonEdge_Empower_2,Item_DemonEdge_Empower_3"
+	
+	showinpractice="true"
+>
+
+	<!-- tool tip only -->
+	<constant name="damage" value="18" adjustment="item" qualityvalue="1.8" qualityadjustment="common" op="add"/>
+	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+	<constant name="damage_legendary" value="2" adjustment="none" qualityvalue="2" qualityadjustment="legendary" op="add"/>
+
+	<modifier key="demonedge_legendary" modpriority="80" basedamage="22"/>
+	
+
+
+</crafteditem>
+
+

--- a/game/items/recipes/damage/demon_edge/item.entity
+++ b/game/items/recipes/damage/demon_edge/item.entity
@@ -10,7 +10,7 @@
     
     
     actiontype="passive"
-    basedamage="22"
+    basedamage="21"
     basedamageperquality="1.8"
 
 
@@ -23,7 +23,7 @@
 >
 
     <!-- tool tip only -->
-    <constant name="damage" value="22" adjustment="item" qualityvalue="1.8" qualityadjustment="common" op="add"/>
+    <constant name="damage" value="21" adjustment="item" qualityvalue="1.8" qualityadjustment="common" op="add"/>
     <constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
     <constant name="damage_legendary" value="2" adjustment="none" qualityvalue="2" qualityadjustment="legendary" op="add"/>
 

--- a/game/items/recipes/damage/demon_edge/item.entity
+++ b/game/items/recipes/damage/demon_edge/item.entity
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <crafteditem
-	name="Item_DemonEdge"
-	
-	icon="icon.tga"
-	
-	cost="900"
-	components="Item_Blade Item_Blade Item_GlovesOfHaste"
-	craftingmaxcomponents="3"
-	
-	
-	actiontype="passive"
-	basedamage="18"
-	basedamageperquality="1.8"
+    name="Item_DemonEdge"
+    
+    icon="icon.tga"
+    
+    cost="900"
+    components="Item_Blade Item_Blade Item_GlovesOfHaste"
+    craftingmaxcomponents="3"
+    
+    
+    actiontype="passive"
+    basedamage="22"
+    basedamageperquality="1.8"
 
 
 
-	filters="attack_damage,attack"
+    filters="attack_damage,attack"
 
-	empoweredeffects="Item_DemonEdge_Empower_2,Item_DemonEdge_Empower_3"
-	
-	showinpractice="true"
+    empoweredeffects="Item_DemonEdge_Empower_2,Item_DemonEdge_Empower_3"
+    
+    showinpractice="true"
 >
 
-	<!-- tool tip only -->
-	<constant name="damage" value="18" adjustment="item" qualityvalue="1.8" qualityadjustment="common" op="add"/>
-	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
-	<constant name="damage_legendary" value="2" adjustment="none" qualityvalue="2" qualityadjustment="legendary" op="add"/>
+    <!-- tool tip only -->
+    <constant name="damage" value="22" adjustment="item" qualityvalue="1.8" qualityadjustment="common" op="add"/>
+    <constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+    <constant name="damage_legendary" value="2" adjustment="none" qualityvalue="2" qualityadjustment="legendary" op="add"/>
 
-	<modifier key="demonedge_legendary" modpriority="80" basedamage="22"/>
-	
+    <modifier key="demonedge_legendary" modpriority="80" basedamage="22"/>
+    
 
 
 </crafteditem>

--- a/game/items/recipes/damage/frostbrand/item.entity
+++ b/game/items/recipes/damage/frostbrand/item.entity
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<crafteditem
+	name="Item_Frostbrand"
+	
+	icon="icon.tga"
+	statuseffecttooltip="State_Frostbrand"
+	
+	cost="1150"
+	components="Item_GlovesOfHaste Item_Staff"
+	basedamage="10"
+	basedamageperquality="1"
+	
+	actiontype="passive"
+
+	filters="utility,attack,attack_damage,debuff_enemy,attack_mod"
+
+	empoweredeffects="Item_Frostbrand_Empower_1,Item_Frostbrand_Empower_2,Item_Frostbrand_Empower_3"
+
+	
+	showinpractice="true"
+	>
+	<constant name="slow" value="20" adjustment="none" qualityvalue="2" qualityadjustment="common" op="add"/>
+	<constant name="damage" value="10" adjustment="item" qualityvalue="1" qualityadjustment="common" op="add"/>
+	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+	<constant name="movespeed" value="8" adjustment="none" qualityvalue="8" qualityadjustment="legendary" op="add"/>
+	<onattackimpact  >
+		<condition test="bounce_count lt 2">
+			<cantarget targetscheme="enemy_units" effecttype="">			
+				<condition test="target_type melee" target="source_entity">
+					<applystate name="State_Frostbrand" duration="2000" />
+				</condition>
+				<condition test="target_type ranged" target="source_entity">
+					<applystate name="State_FrostbrandRanged" duration="2000" />
+				</condition>
+				
+				<playeffect effect="effects/impact.effect" source="target_entity" target="target_entity"/>
+
+			</cantarget>
+		</condition>
+	</onattackimpact>
+	
+</crafteditem>

--- a/game/items/recipes/damage/frostbrand/item.entity
+++ b/game/items/recipes/damage/frostbrand/item.entity
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <crafteditem
-	name="Item_Frostbrand"
-	
-	icon="icon.tga"
-	statuseffecttooltip="State_Frostbrand"
-	
-	cost="1150"
-	components="Item_GlovesOfHaste Item_Staff"
-	basedamage="10"
-	basedamageperquality="1"
-	
-	actiontype="passive"
+    name="Item_Frostbrand"
+    
+    icon="icon.tga"
+    statuseffecttooltip="State_Frostbrand"
+    
+    cost="1150"
+    components="Item_GlovesOfHaste Item_Staff"
+    basedamage="12"
+    basedamageperquality="1"
+    
+    actiontype="passive"
 
-	filters="utility,attack,attack_damage,debuff_enemy,attack_mod"
+    filters="utility,attack,attack_damage,debuff_enemy,attack_mod"
 
-	empoweredeffects="Item_Frostbrand_Empower_1,Item_Frostbrand_Empower_2,Item_Frostbrand_Empower_3"
+    empoweredeffects="Item_Frostbrand_Empower_1,Item_Frostbrand_Empower_2,Item_Frostbrand_Empower_3"
 
-	
-	showinpractice="true"
-	>
-	<constant name="slow" value="20" adjustment="none" qualityvalue="2" qualityadjustment="common" op="add"/>
-	<constant name="damage" value="10" adjustment="item" qualityvalue="1" qualityadjustment="common" op="add"/>
-	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
-	<constant name="movespeed" value="8" adjustment="none" qualityvalue="8" qualityadjustment="legendary" op="add"/>
-	<onattackimpact  >
-		<condition test="bounce_count lt 2">
-			<cantarget targetscheme="enemy_units" effecttype="">			
-				<condition test="target_type melee" target="source_entity">
-					<applystate name="State_Frostbrand" duration="2000" />
-				</condition>
-				<condition test="target_type ranged" target="source_entity">
-					<applystate name="State_FrostbrandRanged" duration="2000" />
-				</condition>
-				
-				<playeffect effect="effects/impact.effect" source="target_entity" target="target_entity"/>
+    
+    showinpractice="true"
+    >
+    <constant name="slow" value="20" adjustment="none" qualityvalue="2" qualityadjustment="common" op="add"/>
+    <constant name="damage" value="12" adjustment="item" qualityvalue="1" qualityadjustment="common" op="add"/>
+    <constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+    <constant name="movespeed" value="8" adjustment="none" qualityvalue="8" qualityadjustment="legendary" op="add"/>
+    <onattackimpact  >
+        <condition test="bounce_count lt 2">
+            <cantarget targetscheme="enemy_units" effecttype="">			
+                <condition test="target_type melee" target="source_entity">
+                    <applystate name="State_Frostbrand" duration="2000" />
+                </condition>
+                <condition test="target_type ranged" target="source_entity">
+                    <applystate name="State_FrostbrandRanged" duration="2000" />
+                </condition>
+                
+                <playeffect effect="effects/impact.effect" source="target_entity" target="target_entity"/>
 
-			</cantarget>
-		</condition>
-	</onattackimpact>
-	
+            </cantarget>
+        </condition>
+    </onattackimpact>
+    
 </crafteditem>

--- a/game/items/recipes/damage/riftshards/item.entity
+++ b/game/items/recipes/damage/riftshards/item.entity
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<crafteditem
+	name="Item_Riftshards"
+
+	icon="icon.tga"
+	
+	cost="1500"
+	components="Item_Relic Item_GlovesOfHaste Item_GlovesOfHaste"
+	
+	
+	actiontype="passive"
+	filters="power,attack,crit,attack_damage"
+
+	empoweredeffects="Item_Riftshards_Empower_1,Item_Riftshards_Empower_2"
+	
+	showinpractice="true"
+>
+	<constant name="attack_damage" value="10" adjustment="item" qualityvalue="1" qualityadjustment="common" op="add"/>
+	<constant name="critchance" value="20" adjustment="none" qualityvalue="2.0" qualityadjustment="common" op="add"/>
+	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+	<constant name="resistance" value="6" adjustment="none" qualityvalue="6" qualityadjustment="legendary" op="add"/>
+	
+	<modifier key="riftshards" modpriority="50" exclusive="true" 
+		basedamage="10"
+		basedamageperquality="1"
+		unitcriticalchance="0.20" 
+		unitcriticalstrikechanceperquality="0.020" 
+	>
+
+	</modifier>
+	
+
+
+</crafteditem>

--- a/game/items/recipes/damage/riftshards/item.entity
+++ b/game/items/recipes/damage/riftshards/item.entity
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <crafteditem
-	name="Item_Riftshards"
+    name="Item_Riftshards"
 
-	icon="icon.tga"
-	
-	cost="1500"
-	components="Item_Relic Item_GlovesOfHaste Item_GlovesOfHaste"
-	
-	
-	actiontype="passive"
-	filters="power,attack,crit,attack_damage"
+    icon="icon.tga"
+    
+    cost="1500"
+    components="Item_Relic Item_GlovesOfHaste Item_GlovesOfHaste"
+    
+    
+    actiontype="passive"
+    filters="power,attack,crit,attack_damage"
 
-	empoweredeffects="Item_Riftshards_Empower_1,Item_Riftshards_Empower_2"
-	
-	showinpractice="true"
+    empoweredeffects="Item_Riftshards_Empower_1,Item_Riftshards_Empower_2"
+    
+    showinpractice="true"
 >
-	<constant name="attack_damage" value="10" adjustment="item" qualityvalue="1" qualityadjustment="common" op="add"/>
-	<constant name="critchance" value="20" adjustment="none" qualityvalue="2.0" qualityadjustment="common" op="add"/>
-	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
-	<constant name="resistance" value="6" adjustment="none" qualityvalue="6" qualityadjustment="legendary" op="add"/>
-	
-	<modifier key="riftshards" modpriority="50" exclusive="true" 
-		basedamage="10"
-		basedamageperquality="1"
-		unitcriticalchance="0.20" 
-		unitcriticalstrikechanceperquality="0.020" 
-	>
+    <constant name="attack_damage" value="12" adjustment="item" qualityvalue="1" qualityadjustment="common" op="add"/>
+    <constant name="critchance" value="20" adjustment="none" qualityvalue="2.0" qualityadjustment="common" op="add"/>
+    <constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+    <constant name="resistance" value="6" adjustment="none" qualityvalue="6" qualityadjustment="legendary" op="add"/>
+    
+    <modifier key="riftshards" modpriority="50" exclusive="true" 
+        basedamage="12"
+        basedamageperquality="1"
+        unitcriticalchance="0.20" 
+        unitcriticalstrikechanceperquality="0.020" 
+    >
 
-	</modifier>
-	
+    </modifier>
+    
 
 
 </crafteditem>

--- a/game/items/recipes/damage/shieldbreaker/item.entity
+++ b/game/items/recipes/damage/shieldbreaker/item.entity
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<crafteditem
+	name="Item_Shieldbreaker"
+	
+	icon="icon.tga"
+	
+	cost="1150"
+	components="Item_Staff Item_Healthstone Item_Healthstone"
+
+	basedamage="5"
+	basedamageperquality="0.5"
+
+	actiontype="passive"
+	filters="attack,attack_mod,attack_damage"
+
+	empoweredeffects="Item_Shieldbreaker_Empower_1,Item_Shieldbreaker_Empower_3"
+	
+	showinpractice="true"
+>
+	<constant name="attack_damage" value="5" adjustment="item" qualityvalue="0.5" qualityadjustment="common" op="add"/>
+	<constant name="resistance" value="40" adjustment="none" qualityvalue="4" qualityadjustment="common" op="add"/>
+	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+	<constant name="legendary" value="0.5" adjustment="none" qualityvalue="0.5" qualityadjustment="legendary" op="add"/>
+	<onattackimpact />
+
+	<onattackingdamageevent>
+		<cantarget targetscheme="enemy_units">
+			<getconstant name="resistance" />
+			<setvar0 a="result" b="100" op="div" />
+			<setvalue name="damage_armorpiercepercent" a="damage_armorpiercepercent" b="var0" op="add" />
+		</cantarget>
+	</onattackingdamageevent>
+
+</crafteditem>

--- a/game/items/recipes/damage/shieldbreaker/item.entity
+++ b/game/items/recipes/damage/shieldbreaker/item.entity
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <crafteditem
-	name="Item_Shieldbreaker"
-	
-	icon="icon.tga"
-	
-	cost="1150"
-	components="Item_Staff Item_Healthstone Item_Healthstone"
+    name="Item_Shieldbreaker"
+    
+    icon="icon.tga"
+    
+    cost="1150"
+    components="Item_Staff Item_Healthstone Item_Healthstone"
 
-	basedamage="5"
-	basedamageperquality="0.5"
+    basedamage="6"
+    basedamageperquality="0.5"
 
-	actiontype="passive"
-	filters="attack,attack_mod,attack_damage"
+    actiontype="passive"
+    filters="attack,attack_mod,attack_damage"
 
-	empoweredeffects="Item_Shieldbreaker_Empower_1,Item_Shieldbreaker_Empower_3"
-	
-	showinpractice="true"
+    empoweredeffects="Item_Shieldbreaker_Empower_1,Item_Shieldbreaker_Empower_3"
+    
+    showinpractice="true"
 >
-	<constant name="attack_damage" value="5" adjustment="item" qualityvalue="0.5" qualityadjustment="common" op="add"/>
-	<constant name="resistance" value="40" adjustment="none" qualityvalue="4" qualityadjustment="common" op="add"/>
-	<constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
-	<constant name="legendary" value="0.5" adjustment="none" qualityvalue="0.5" qualityadjustment="legendary" op="add"/>
-	<onattackimpact />
+    <constant name="attack_damage" value="6" adjustment="item" qualityvalue="0.5" qualityadjustment="common" op="add"/>
+    <constant name="resistance" value="40" adjustment="none" qualityvalue="4" qualityadjustment="common" op="add"/>
+    <constant name="common_increase" value="0" adjustment="none" qualityvalue="10" qualityadjustment="common" op="add"/>
+    <constant name="legendary" value="0.5" adjustment="none" qualityvalue="0.5" qualityadjustment="legendary" op="add"/>
+    <onattackimpact />
 
-	<onattackingdamageevent>
-		<cantarget targetscheme="enemy_units">
-			<getconstant name="resistance" />
-			<setvar0 a="result" b="100" op="div" />
-			<setvalue name="damage_armorpiercepercent" a="damage_armorpiercepercent" b="var0" op="add" />
-		</cantarget>
-	</onattackingdamageevent>
+    <onattackingdamageevent>
+        <cantarget targetscheme="enemy_units">
+            <getconstant name="resistance" />
+            <setvar0 a="result" b="100" op="div" />
+            <setvalue name="damage_armorpiercepercent" a="damage_armorpiercepercent" b="var0" op="add" />
+        </cantarget>
+    </onattackingdamageevent>
 
 </crafteditem>

--- a/game/items/recipes/defensive/oracles_trinket/item.entity
+++ b/game/items/recipes/defensive/oracles_trinket/item.entity
@@ -20,7 +20,7 @@
     nostun="true"
     noperplex="true"
     nosilence="true"
-    basedamage="5"
+    basedamage="6"
     botitem="OraclesTrinketItem"
     filters="utility,activatable,defense,resistance"
     empoweredeffects="Item_OraclesTrinket_Empower_1,Item_OraclesTrinket_Empower_2"
@@ -29,7 +29,7 @@
     <!-- Health restored by the item if debuff was removed (adjusted by power) -->
     <constant name="heal" value="180" adjustment="item" qualityvalue="10" qualityadjustment="common" op="add"/>
     <!-- Base damage bonus. TOOLTIP ONLY! Actual value used is in "basedamage" attribute! -->
-    <constant name="base_damage" value="5" adjustment="item" qualityvalue="1" qualityadjustment="common" op="add" />
+    <constant name="base_damage" value="6" adjustment="item" qualityvalue="1" qualityadjustment="common" op="add" />
     <!-- CC reduction state duration, seconds -->
     <constant name="cc_state_duration_sec" value="2" adjustment="none" />
     

--- a/game/items/recipes/defensive/stone_skin/item.entity
+++ b/game/items/recipes/defensive/stone_skin/item.entity
@@ -21,7 +21,7 @@
 
     cooldowntime="45000"
 
-    basedamage="10"
+    basedamage="9"
 
     filters="defense,utility,cc_resist,activatable,other_mobility"
     alwaysshowtimer="true"
@@ -31,7 +31,7 @@
     showinpractice="true"
 >
     <!-- Base damage bonus. TOOLTIP ONLY! Real value used is set in "basedamage" attribute! -->
-    <constant name="damage" value="10" adjustment="item" />
+    <constant name="damage" value="9" adjustment="item" />
 
     <!-- Ability duration, seconds -->
     <constant name="duration_sec" value="8" adjustment="none" />

--- a/game/items/recipes/defensive/stone_skin/item.entity
+++ b/game/items/recipes/defensive/stone_skin/item.entity
@@ -21,7 +21,7 @@
 
     cooldowntime="45000"
 
-    basedamage="8"
+    basedamage="10"
 
     filters="defense,utility,cc_resist,activatable,other_mobility"
     alwaysshowtimer="true"
@@ -31,7 +31,7 @@
     showinpractice="true"
 >
     <!-- Base damage bonus. TOOLTIP ONLY! Real value used is set in "basedamage" attribute! -->
-    <constant name="damage" value="8" adjustment="item" />
+    <constant name="damage" value="10" adjustment="item" />
 
     <!-- Ability duration, seconds -->
     <constant name="duration_sec" value="8" adjustment="none" />


### PR DESCRIPTION
Rebalance of attack damage items:
- Dark Bargain:
  - Passive attack damage bonus: 40->46.
  - Permanent attack damage bonus on activation: 8->9.
  - Temporary attack damage bonus on activation: 20->23;
  - Restraint enchantment:
    - Permanent damage bonus on activation: 2->3.
    - Temporary damage bonus on activation: 8->9.
- Demon Edge:
  - Attack damage bonus: 18->21.
  - Brutality enchantment:
    - Attack damage bonus: 5->6.
- Frost Prism:
  - Attack damage bonus: 10->12.
- Woundsplitter:
  - Attack damage bonus: 10->12.
- Crushing Mace:
  - Attack damage bonus: 5->6.
- Oracle's Trinket:
  - Attack damage bonus: 5->6.
- Stone skin:
  - Attack damage bonus: 8->9.