### PR TITLE
Fix Chester levelbuild (typo)

### DIFF
--- a/game/heroes/chester/hero.entity
+++ b/game/heroes/chester/hero.entity
@@ -181,7 +181,7 @@
 
 	defaultfamiliar="Familiar_Mystik"
 	itembuild="Chester"
-	llevelbuild="1,2,1,3,1,4,1,2,2,2,4,3,3,3,4"
+	levelbuild="1,2,1,3,1,4,1,2,2,2,4,3,3,3,4"
 	
 	corpsetime="2000"
 	corpsefadetime="4000"


### PR DESCRIPTION
Fix a typo in **Chester's** `hero.entity` file which causes **Chester** to not have a `levelbuild` in the default **S2 Hero Guide**.