### PR TITLE
Apex emitter fix

### DIFF
--- a/game/heroes/ace/ability_02/effects/impact.effect
+++ b/game/heroes/ace/ability_02/effects/impact.effect
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<effect deferred="1">
+	<definitions>
+
+		<particlesystem name="system0" space="world"  scale="2.5">
+			
+			<sound
+				volume="0"
+				falloffstart="500"
+				falloffend="2500"
+				sample="../sounds/sfx_impact.wav"
+			/>
+			
+			<light
+				life="750"
+				startcolor="0 5 10"
+				endcolor="0 0 0"
+				midcolorpos=".5"
+				falloffstart="0"
+				falloffend="150"
+				position="0 0 75"
+			/>
+			
+
+			<groundsprite
+				position="0 0 0"
+				life="1500"
+				material="/shared/effects/smaterials/snowy_groundsprite.material"
+				startsize="75"
+				midsize="145"
+				endsize="145"
+				midsizepos=".05"
+				color=".5 .6 .75"
+				startalpha="1"
+				endalpha="0"
+
+			/>
+
+			<groundsprite
+				position="0 0 0"
+				life="1250"
+				material="/shared/effects/smaterials/snowy_cracks_reveal.material"
+				startsize="145"
+				midsize="145"
+				endsize="145"
+				midsizepos=".2"
+				color=".7 .85 1"
+				startframe="1"
+				endframe=".10"
+				alpha=".35"
+			/>
+
+			<groundsprite
+				delay="1250"
+				position="0 0 0"
+				life="250"
+				material="/shared/effects/smaterials/snowy_cracks.material"
+				startsize="145"
+				midsize="145"
+				endsize="145"
+				midsizepos=".1"
+				color=".7 .85 1"
+				startalpha=".35"
+				endalpha="0"
+			/>
+
+			<model
+				position="0 50 0"
+				minlife="18000"
+				maxlife="22000"
+				model="rocks/model.mdf"
+				anim="idle_slower"
+				color="1 2 3"
+				expirelife="500"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".9"
+				minstartscale=".225"
+				maxstartscale=".275"
+				midscale=".15"
+				endscale=".15"
+				directionalspace="local"
+				minyaw="0"
+				maxyaw="0"
+			/>
+
+			<model
+				position="55 0 -5"
+				minlife="18000"
+				maxlife="22000"
+				model="rocks/model.mdf"
+				anim="idle_slower"
+				color="1 2 3"
+				expirelife="500"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".9"
+				minstartscale=".225"
+				maxstartscale=".275"
+				midscale=".15"
+				endscale=".15"
+				directionalspace="local"
+			/>
+
+			<model
+				position="0 -55 -5"
+				minlife="18000"
+				maxlife="22000"
+				model="rocks/model.mdf"
+				anim="idle_slower"
+				color="1 2 3"
+				expirelife="500"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".9"
+				minstartscale=".225"
+				maxstartscale=".275"
+				midscale=".15"
+				endscale=".15"
+				directionalspace="local"
+			/>
+
+			<model
+				position="-50 -12 -5"
+				minlife="18000"
+				maxlife="22000"
+				model="rocks/model.mdf"
+				anim="idle_slower"
+				color="1 2 3"
+				expirelife="500"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".9"
+				minstartscale=".225"
+				maxstartscale=".275"
+				midscale=".15"
+				endscale=".15"
+				directionalspace="local"
+			/>
+
+			
+			
+
+			<simpleemitter
+			delay="100"
+				count="100"
+				position="0 0 0"
+				spawnrate="100"			
+				minparticlelife="250"
+				maxparticlelife="500"
+				gravity="0"
+				material="/shared/effects/smaterials/snowy_smoke.material"
+				offsetradial="90 0 12"
+				direction="0 0 1"
+				minangle="0"
+				maxangle="1"
+				minspeed="0"				
+				maxspeed="175"				
+			>
+				<particle
+					startsize="50"								
+					minendsize="100"
+					maxendsize="100"
+					startcolor="1 1 1"
+					midcolor=".5 .75 1"
+					endcolor=".5 .75 1"
+					startalpha="0"
+					midalpha=".06"
+					endalpha="0"
+					lockup="true"
+					lockright="true"
+					pitch="-90"
+				/>
+			</simpleemitter>
+			
+			<model
+				position="0 -10 0"
+				life="1250"
+				model="more_rocks/model.mdf"
+				anim="idle"
+				color=".2 .8 1"
+				expirelife="500"
+				startalpha=".6"
+				midalpha=".6"
+				endalpha="0"
+				midalphapos=".75"
+				scale=".225"
+				directionalspace="local"
+				yaw="-90"
+			>
+			</model>
+
+			<simpleemitter
+				count="100"
+				position="0 0 0"
+				spawnrate="2000"
+				minparticlelife="250"
+				maxparticlelife="500"
+				gravity="50"
+				material="/shared/effects/smaterials/whitedot.material"
+				offsetsphere="12 12 75"
+				direction="0 0 1"
+				minangle="0"
+				maxangle="1"
+				minspeed="250"
+				maxspeed="500"
+
+			>
+				<particle
+					size="5"
+					startcolor=".5"
+					midcolor=".25 .35 .5"
+					endcolor="0 0 0"
+				/>
+			</simpleemitter>
+			
+			<billboard
+				position="0 0 10"
+				life="1500"
+				material="/shared/effects/smaterials/whitedot.material"
+				startsize="45"
+				midsize="250"
+				endsize="250"
+				midsizepos=".5"
+				startcolor=".1 .5 .7"
+				midcolor=".1 .5 .7"
+				endcolor="0 0 0"
+				midcolorpos=".75"
+				lockup="1"
+				lockright="1"
+				pitch="90"
+				depthbias="-50"
+			/>
+
+		</particlesystem>
+		
+		
+		
+		
+		
+		
+		<!-- Particle system with APEX emitter and non-APEX fallback -->
+		<particlesystem name="system0_apex" space="entity" scale="1">
+
+			<apexemitter asset="ace_W" position="0 0 0" />
+
+		</particlesystem>
+
+
+
+	</definitions>
+	<thread>
+		<spawnparticlesystem instance="instance0" particlesystem="system0" />
+		<spawnparticlesystem instance="instance1" particlesystem="system0_apex" />
+		<camerashake2 scale="25" radius="3000" duration="250" frequency="22" />
+		<waitfordeath instance="instance0" />
+		<waitfordeath instance="instance1" />
+		<wait duration="6000"/>
+	</thread>
+</effect>
+
+<!-- [min|max][start|mid|end]property[speed][position] -->
+

--- a/game/heroes/ace/ability_02/effects/impact.effect
+++ b/game/heroes/ace/ability_02/effects/impact.effect
@@ -1,266 +1,263 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <effect deferred="1">
-	<definitions>
+    <definitions>
 
-		<particlesystem name="system0" space="world"  scale="2.5">
-			
-			<sound
-				volume="0"
-				falloffstart="500"
-				falloffend="2500"
-				sample="../sounds/sfx_impact.wav"
-			/>
-			
-			<light
-				life="750"
-				startcolor="0 5 10"
-				endcolor="0 0 0"
-				midcolorpos=".5"
-				falloffstart="0"
-				falloffend="150"
-				position="0 0 75"
-			/>
-			
+        <particlesystem name="system0" space="world"  scale="2.5">
+            
+            <sound
+                volume="0"
+                falloffstart="500"
+                falloffend="2500"
+                sample="../sounds/sfx_impact.wav"
+            />
+            
+            <light
+                life="750"
+                startcolor="0 5 10"
+                endcolor="0 0 0"
+                midcolorpos=".5"
+                falloffstart="0"
+                falloffend="150"
+                position="0 0 75"
+            />
+            
 
-			<groundsprite
-				position="0 0 0"
-				life="1500"
-				material="/shared/effects/smaterials/snowy_groundsprite.material"
-				startsize="75"
-				midsize="145"
-				endsize="145"
-				midsizepos=".05"
-				color=".5 .6 .75"
-				startalpha="1"
-				endalpha="0"
+            <groundsprite
+                position="0 0 0"
+                life="1500"
+                material="/shared/effects/smaterials/snowy_groundsprite.material"
+                startsize="75"
+                midsize="145"
+                endsize="145"
+                midsizepos=".05"
+                color=".5 .6 .75"
+                startalpha="1"
+                endalpha="0"
 
-			/>
+            />
 
-			<groundsprite
-				position="0 0 0"
-				life="1250"
-				material="/shared/effects/smaterials/snowy_cracks_reveal.material"
-				startsize="145"
-				midsize="145"
-				endsize="145"
-				midsizepos=".2"
-				color=".7 .85 1"
-				startframe="1"
-				endframe=".10"
-				alpha=".35"
-			/>
+            <groundsprite
+                position="0 0 0"
+                life="1250"
+                material="/shared/effects/smaterials/snowy_cracks_reveal.material"
+                startsize="145"
+                midsize="145"
+                endsize="145"
+                midsizepos=".2"
+                color=".7 .85 1"
+                startframe="1"
+                endframe=".10"
+                alpha=".35"
+            />
 
-			<groundsprite
-				delay="1250"
-				position="0 0 0"
-				life="250"
-				material="/shared/effects/smaterials/snowy_cracks.material"
-				startsize="145"
-				midsize="145"
-				endsize="145"
-				midsizepos=".1"
-				color=".7 .85 1"
-				startalpha=".35"
-				endalpha="0"
-			/>
+            <groundsprite
+                delay="1250"
+                position="0 0 0"
+                life="250"
+                material="/shared/effects/smaterials/snowy_cracks.material"
+                startsize="145"
+                midsize="145"
+                endsize="145"
+                midsizepos=".1"
+                color=".7 .85 1"
+                startalpha=".35"
+                endalpha="0"
+            />
 
-			<model
-				position="0 50 0"
-				minlife="18000"
-				maxlife="22000"
-				model="rocks/model.mdf"
-				anim="idle_slower"
-				color="1 2 3"
-				expirelife="500"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".9"
-				minstartscale=".225"
-				maxstartscale=".275"
-				midscale=".15"
-				endscale=".15"
-				directionalspace="local"
-				minyaw="0"
-				maxyaw="0"
-			/>
+            <model
+                position="0 50 0"
+                minlife="18000"
+                maxlife="22000"
+                model="rocks/model.mdf"
+                anim="idle_slower"
+                color="1 2 3"
+                expirelife="500"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".9"
+                minstartscale=".225"
+                maxstartscale=".275"
+                midscale=".15"
+                endscale=".15"
+                directionalspace="local"
+                minyaw="0"
+                maxyaw="0"
+            />
 
-			<model
-				position="55 0 -5"
-				minlife="18000"
-				maxlife="22000"
-				model="rocks/model.mdf"
-				anim="idle_slower"
-				color="1 2 3"
-				expirelife="500"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".9"
-				minstartscale=".225"
-				maxstartscale=".275"
-				midscale=".15"
-				endscale=".15"
-				directionalspace="local"
-			/>
+            <model
+                position="55 0 -5"
+                minlife="18000"
+                maxlife="22000"
+                model="rocks/model.mdf"
+                anim="idle_slower"
+                color="1 2 3"
+                expirelife="500"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".9"
+                minstartscale=".225"
+                maxstartscale=".275"
+                midscale=".15"
+                endscale=".15"
+                directionalspace="local"
+            />
 
-			<model
-				position="0 -55 -5"
-				minlife="18000"
-				maxlife="22000"
-				model="rocks/model.mdf"
-				anim="idle_slower"
-				color="1 2 3"
-				expirelife="500"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".9"
-				minstartscale=".225"
-				maxstartscale=".275"
-				midscale=".15"
-				endscale=".15"
-				directionalspace="local"
-			/>
+            <model
+                position="0 -55 -5"
+                minlife="18000"
+                maxlife="22000"
+                model="rocks/model.mdf"
+                anim="idle_slower"
+                color="1 2 3"
+                expirelife="500"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".9"
+                minstartscale=".225"
+                maxstartscale=".275"
+                midscale=".15"
+                endscale=".15"
+                directionalspace="local"
+            />
 
-			<model
-				position="-50 -12 -5"
-				minlife="18000"
-				maxlife="22000"
-				model="rocks/model.mdf"
-				anim="idle_slower"
-				color="1 2 3"
-				expirelife="500"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".9"
-				minstartscale=".225"
-				maxstartscale=".275"
-				midscale=".15"
-				endscale=".15"
-				directionalspace="local"
-			/>
+            <model
+                position="-50 -12 -5"
+                minlife="18000"
+                maxlife="22000"
+                model="rocks/model.mdf"
+                anim="idle_slower"
+                color="1 2 3"
+                expirelife="500"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".9"
+                minstartscale=".225"
+                maxstartscale=".275"
+                midscale=".15"
+                endscale=".15"
+                directionalspace="local"
+            />
 
-			
-			
+            
+            
 
-			<simpleemitter
-			delay="100"
-				count="100"
-				position="0 0 0"
-				spawnrate="100"			
-				minparticlelife="250"
-				maxparticlelife="500"
-				gravity="0"
-				material="/shared/effects/smaterials/snowy_smoke.material"
-				offsetradial="90 0 12"
-				direction="0 0 1"
-				minangle="0"
-				maxangle="1"
-				minspeed="0"				
-				maxspeed="175"				
-			>
-				<particle
-					startsize="50"								
-					minendsize="100"
-					maxendsize="100"
-					startcolor="1 1 1"
-					midcolor=".5 .75 1"
-					endcolor=".5 .75 1"
-					startalpha="0"
-					midalpha=".06"
-					endalpha="0"
-					lockup="true"
-					lockright="true"
-					pitch="-90"
-				/>
-			</simpleemitter>
-			
-			<model
-				position="0 -10 0"
-				life="1250"
-				model="more_rocks/model.mdf"
-				anim="idle"
-				color=".2 .8 1"
-				expirelife="500"
-				startalpha=".6"
-				midalpha=".6"
-				endalpha="0"
-				midalphapos=".75"
-				scale=".225"
-				directionalspace="local"
-				yaw="-90"
-			>
-			</model>
+            <simpleemitter
+            delay="100"
+                count="100"
+                position="0 0 0"
+                spawnrate="100"			
+                minparticlelife="250"
+                maxparticlelife="500"
+                gravity="0"
+                material="/shared/effects/smaterials/snowy_smoke.material"
+                offsetradial="90 0 12"
+                direction="0 0 1"
+                minangle="0"
+                maxangle="1"
+                minspeed="0"				
+                maxspeed="175"				
+            >
+                <particle
+                    startsize="50"								
+                    minendsize="100"
+                    maxendsize="100"
+                    startcolor="1 1 1"
+                    midcolor=".5 .75 1"
+                    endcolor=".5 .75 1"
+                    startalpha="0"
+                    midalpha=".06"
+                    endalpha="0"
+                    lockup="true"
+                    lockright="true"
+                    pitch="-90"
+                />
+            </simpleemitter>
+            
+            <model
+                position="0 -10 0"
+                life="1250"
+                model="more_rocks/model.mdf"
+                anim="idle"
+                color=".2 .8 1"
+                expirelife="500"
+                startalpha=".6"
+                midalpha=".6"
+                endalpha="0"
+                midalphapos=".75"
+                scale=".225"
+                directionalspace="local"
+                yaw="-90"
+            >
+            </model>
 
-			<simpleemitter
-				count="100"
-				position="0 0 0"
-				spawnrate="2000"
-				minparticlelife="250"
-				maxparticlelife="500"
-				gravity="50"
-				material="/shared/effects/smaterials/whitedot.material"
-				offsetsphere="12 12 75"
-				direction="0 0 1"
-				minangle="0"
-				maxangle="1"
-				minspeed="250"
-				maxspeed="500"
+            <simpleemitter
+                count="100"
+                position="0 0 0"
+                spawnrate="2000"
+                minparticlelife="250"
+                maxparticlelife="500"
+                gravity="50"
+                material="/shared/effects/smaterials/whitedot.material"
+                offsetsphere="12 12 75"
+                direction="0 0 1"
+                minangle="0"
+                maxangle="1"
+                minspeed="250"
+                maxspeed="500"
 
-			>
-				<particle
-					size="5"
-					startcolor=".5"
-					midcolor=".25 .35 .5"
-					endcolor="0 0 0"
-				/>
-			</simpleemitter>
-			
-			<billboard
-				position="0 0 10"
-				life="1500"
-				material="/shared/effects/smaterials/whitedot.material"
-				startsize="45"
-				midsize="250"
-				endsize="250"
-				midsizepos=".5"
-				startcolor=".1 .5 .7"
-				midcolor=".1 .5 .7"
-				endcolor="0 0 0"
-				midcolorpos=".75"
-				lockup="1"
-				lockright="1"
-				pitch="90"
-				depthbias="-50"
-			/>
+            >
+                <particle
+                    size="5"
+                    startcolor=".5"
+                    midcolor=".25 .35 .5"
+                    endcolor="0 0 0"
+                />
+            </simpleemitter>
+            
+            <billboard
+                position="0 0 10"
+                life="1500"
+                material="/shared/effects/smaterials/whitedot.material"
+                startsize="45"
+                midsize="250"
+                endsize="250"
+                midsizepos=".5"
+                startcolor=".1 .5 .7"
+                midcolor=".1 .5 .7"
+                endcolor="0 0 0"
+                midcolorpos=".75"
+                lockup="1"
+                lockright="1"
+                pitch="90"
+                depthbias="-50"
+            />
 
-		</particlesystem>
-		
-		
-		
-		
-		
-		
-		<!-- Particle system with APEX emitter and non-APEX fallback -->
-		<particlesystem name="system0_apex" space="entity" scale="1">
+        </particlesystem>
 
-			<apexemitter asset="ace_W" position="0 0 0" />
+        <!-- Particle system with APEX emitter and non-APEX fallback -->
+        <!-- TheChiprel: APEX emitters are disabled, since they prevent effects from expiring.  -->
+        <!--       At the same time they do nothing visually and probably don't work at all     -->
+        <!--
+        <particlesystem name="system0_apex" space="entity" scale="1">
 
-		</particlesystem>
+            <apexemitter asset="ace_W" position="0 0 0" />
 
+        </particlesystem>
+        -->
 
-
-	</definitions>
-	<thread>
-		<spawnparticlesystem instance="instance0" particlesystem="system0" />
-		<spawnparticlesystem instance="instance1" particlesystem="system0_apex" />
-		<camerashake2 scale="25" radius="3000" duration="250" frequency="22" />
-		<waitfordeath instance="instance0" />
-		<waitfordeath instance="instance1" />
-		<wait duration="6000"/>
-	</thread>
+    </definitions>
+    
+    <thread>
+        <spawnparticlesystem instance="instance0" particlesystem="system0" />
+        <!--spawnparticlesystem instance="instance1" particlesystem="system0_apex" /-->
+        <camerashake2 scale="25" radius="3000" duration="250" frequency="22" />
+        <waitfordeath instance="instance0" />
+        <!--waitfordeath instance="instance1" /-->
+    </thread>
 </effect>
 
 <!-- [min|max][start|mid|end]property[speed][position] -->

--- a/game/heroes/carter/ability_02/effects/impact.effect
+++ b/game/heroes/carter/ability_02/effects/impact.effect
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<effect deferred="true">
+	<definitions>
+		<particlesystem name="system0" space="world" scale="2.25">
+
+			<sound 
+				falloffstart="500"
+				falloffend="2500"
+				volume=".85"
+				sample="../sounds/sfx_impact.wav"
+			/>
+
+			<groundsprite
+				position="0 35 0"
+				life="1000"
+				material="/shared/effects/smaterials/puke.material"
+				startsize="40"
+				midsize="65"
+				endsize="65"
+				midsizepos=".05"
+				color=".7 .8 .7"
+				startalpha=".35"
+				midalpha=".35"
+				endalpha="0"
+			/>
+
+			<groundsprite
+				position="0 -10 0"
+				life="1000"
+				material="/shared/effects/smaterials/puke.material"
+				startsize="50"
+				midsize="105"
+				endsize="105"
+				midsizepos=".15"
+				color=".7 .8 .7"
+				startalpha=".35"
+				midalpha=".35"
+				endalpha="0"
+			/>
+
+			<groundsprite
+				position="0 0 0"
+				life="1000"
+				material="/shared/effects/smaterials/whitedot_ground.material"
+				startsize="40"
+				midsize="142"
+				endsize="142"
+				midsizepos=".1"
+				startcolor=".2 .4 0"
+				midcolor=".2 .4 0"
+				endcolor="0 0 0"
+				midcolorpos=".8"
+			/>
+
+			<simpleemitter
+				life="650"
+				spawnrate="16"		
+				particlelife="1000"					
+				position="0 0 0"
+				offsetsphere="85 85 0"
+				direction="0 0 1"
+				minangle="0"
+				maxangle="1"
+				minspeed="0"
+				maxspeed="0"
+			>
+				<particle
+				> 
+					<model
+						minlife="300"
+						maxlife="600"
+						position="0 0 0"
+						model="bubble/model.mdf"
+						anim="idle"
+						color="1 1 1"
+						startalpha="1"
+						midalpha="1"
+						endalpha="0"
+						startscale=".4"
+						midscale=".8"
+						endscale="0"
+						midscalepos=".85"
+					/>
+					
+					<billboard
+						position="0 0 0"
+						life="500"
+						material="/shared/effects/smaterials/whitedot.material"
+						startsize="40"
+						midsize="65"
+						endsize="65"
+						startcolor=".25 .5 0"
+						endcolor="0 0 0"
+						lockup="1"
+						lockright="1"
+						pitch="90"
+						depthbias="-50"
+					/>
+					
+					<billboard
+						position="0 0 10"
+						life="200"
+						param="0.1"
+						startsize="75"
+						endsize="150"
+						startalpha=".25"
+						midalpha=".25"
+						endalpha="0"
+						material="/shared/effects/smaterials/refract_swell.material"
+						lockup="1"
+						lockright="1"
+						pitch="90"
+						depthbias="-50"
+					/>
+				</particle>
+			</simpleemitter>
+
+			<model
+				position="0 8 -5"
+				life="1250"
+				model="puddle/model.mdf"
+				anim="idle"
+				scale="1.4"
+				startalpha="0"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".2"
+			>
+			</model>
+
+			<model
+				position="0 0 0"
+				life="12500"
+				model="junk/model.mdf"
+				anim="idle" 
+				scale=".35"
+				midscalepos=".1"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".9"
+				minyaw="0"
+				maxyaw="360"
+			/>
+
+		</particlesystem>
+		
+		
+		
+		<!-- Particle system with APEX emitter and non-APEX fallback -->
+		<particlesystem name="system0_apex" space="entity" scale="1">
+
+			<apexemitter asset="carter_W" position="0 0 0"/>
+
+		</particlesystem>
+		
+		
+		
+	</definitions>
+	<thread>
+		<spawnparticlesystem instance="instance0" particlesystem="system0" />
+		<spawnparticlesystem instance="instance1" particlesystem="system0_apex" />
+		<waitfordeath instance="instance0" />
+		<waitfordeath instance="instance1" />
+		<wait duration="6000"/>
+	</thread>
+</effect>

--- a/game/heroes/carter/ability_02/effects/impact.effect
+++ b/game/heroes/carter/ability_02/effects/impact.effect
@@ -1,167 +1,167 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <effect deferred="true">
-	<definitions>
-		<particlesystem name="system0" space="world" scale="2.25">
+    <definitions>
+        <particlesystem name="system0" space="world" scale="2.25">
 
-			<sound 
-				falloffstart="500"
-				falloffend="2500"
-				volume=".85"
-				sample="../sounds/sfx_impact.wav"
-			/>
+            <sound 
+                falloffstart="500"
+                falloffend="2500"
+                volume=".85"
+                sample="../sounds/sfx_impact.wav"
+            />
 
-			<groundsprite
-				position="0 35 0"
-				life="1000"
-				material="/shared/effects/smaterials/puke.material"
-				startsize="40"
-				midsize="65"
-				endsize="65"
-				midsizepos=".05"
-				color=".7 .8 .7"
-				startalpha=".35"
-				midalpha=".35"
-				endalpha="0"
-			/>
+            <groundsprite
+                position="0 35 0"
+                life="1000"
+                material="/shared/effects/smaterials/puke.material"
+                startsize="40"
+                midsize="65"
+                endsize="65"
+                midsizepos=".05"
+                color=".7 .8 .7"
+                startalpha=".35"
+                midalpha=".35"
+                endalpha="0"
+            />
 
-			<groundsprite
-				position="0 -10 0"
-				life="1000"
-				material="/shared/effects/smaterials/puke.material"
-				startsize="50"
-				midsize="105"
-				endsize="105"
-				midsizepos=".15"
-				color=".7 .8 .7"
-				startalpha=".35"
-				midalpha=".35"
-				endalpha="0"
-			/>
+            <groundsprite
+                position="0 -10 0"
+                life="1000"
+                material="/shared/effects/smaterials/puke.material"
+                startsize="50"
+                midsize="105"
+                endsize="105"
+                midsizepos=".15"
+                color=".7 .8 .7"
+                startalpha=".35"
+                midalpha=".35"
+                endalpha="0"
+            />
 
-			<groundsprite
-				position="0 0 0"
-				life="1000"
-				material="/shared/effects/smaterials/whitedot_ground.material"
-				startsize="40"
-				midsize="142"
-				endsize="142"
-				midsizepos=".1"
-				startcolor=".2 .4 0"
-				midcolor=".2 .4 0"
-				endcolor="0 0 0"
-				midcolorpos=".8"
-			/>
+            <groundsprite
+                position="0 0 0"
+                life="1000"
+                material="/shared/effects/smaterials/whitedot_ground.material"
+                startsize="40"
+                midsize="142"
+                endsize="142"
+                midsizepos=".1"
+                startcolor=".2 .4 0"
+                midcolor=".2 .4 0"
+                endcolor="0 0 0"
+                midcolorpos=".8"
+            />
 
-			<simpleemitter
-				life="650"
-				spawnrate="16"		
-				particlelife="1000"					
-				position="0 0 0"
-				offsetsphere="85 85 0"
-				direction="0 0 1"
-				minangle="0"
-				maxangle="1"
-				minspeed="0"
-				maxspeed="0"
-			>
-				<particle
-				> 
-					<model
-						minlife="300"
-						maxlife="600"
-						position="0 0 0"
-						model="bubble/model.mdf"
-						anim="idle"
-						color="1 1 1"
-						startalpha="1"
-						midalpha="1"
-						endalpha="0"
-						startscale=".4"
-						midscale=".8"
-						endscale="0"
-						midscalepos=".85"
-					/>
-					
-					<billboard
-						position="0 0 0"
-						life="500"
-						material="/shared/effects/smaterials/whitedot.material"
-						startsize="40"
-						midsize="65"
-						endsize="65"
-						startcolor=".25 .5 0"
-						endcolor="0 0 0"
-						lockup="1"
-						lockright="1"
-						pitch="90"
-						depthbias="-50"
-					/>
-					
-					<billboard
-						position="0 0 10"
-						life="200"
-						param="0.1"
-						startsize="75"
-						endsize="150"
-						startalpha=".25"
-						midalpha=".25"
-						endalpha="0"
-						material="/shared/effects/smaterials/refract_swell.material"
-						lockup="1"
-						lockright="1"
-						pitch="90"
-						depthbias="-50"
-					/>
-				</particle>
-			</simpleemitter>
+            <simpleemitter
+                life="650"
+                spawnrate="16"		
+                particlelife="1000"					
+                position="0 0 0"
+                offsetsphere="85 85 0"
+                direction="0 0 1"
+                minangle="0"
+                maxangle="1"
+                minspeed="0"
+                maxspeed="0"
+            >
+                <particle
+                > 
+                    <model
+                        minlife="300"
+                        maxlife="600"
+                        position="0 0 0"
+                        model="bubble/model.mdf"
+                        anim="idle"
+                        color="1 1 1"
+                        startalpha="1"
+                        midalpha="1"
+                        endalpha="0"
+                        startscale=".4"
+                        midscale=".8"
+                        endscale="0"
+                        midscalepos=".85"
+                    />
+                    
+                    <billboard
+                        position="0 0 0"
+                        life="500"
+                        material="/shared/effects/smaterials/whitedot.material"
+                        startsize="40"
+                        midsize="65"
+                        endsize="65"
+                        startcolor=".25 .5 0"
+                        endcolor="0 0 0"
+                        lockup="1"
+                        lockright="1"
+                        pitch="90"
+                        depthbias="-50"
+                    />
+                    
+                    <billboard
+                        position="0 0 10"
+                        life="200"
+                        param="0.1"
+                        startsize="75"
+                        endsize="150"
+                        startalpha=".25"
+                        midalpha=".25"
+                        endalpha="0"
+                        material="/shared/effects/smaterials/refract_swell.material"
+                        lockup="1"
+                        lockright="1"
+                        pitch="90"
+                        depthbias="-50"
+                    />
+                </particle>
+            </simpleemitter>
 
-			<model
-				position="0 8 -5"
-				life="1250"
-				model="puddle/model.mdf"
-				anim="idle"
-				scale="1.4"
-				startalpha="0"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".2"
-			>
-			</model>
+            <model
+                position="0 8 -5"
+                life="1250"
+                model="puddle/model.mdf"
+                anim="idle"
+                scale="1.4"
+                startalpha="0"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".2"
+            >
+            </model>
 
-			<model
-				position="0 0 0"
-				life="12500"
-				model="junk/model.mdf"
-				anim="idle" 
-				scale=".35"
-				midscalepos=".1"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".9"
-				minyaw="0"
-				maxyaw="360"
-			/>
+            <model
+                position="0 0 0"
+                life="12500"
+                model="junk/model.mdf"
+                anim="idle" 
+                scale=".35"
+                midscalepos=".1"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".9"
+                minyaw="0"
+                maxyaw="360"
+            />
 
-		</particlesystem>
-		
-		
-		
-		<!-- Particle system with APEX emitter and non-APEX fallback -->
-		<particlesystem name="system0_apex" space="entity" scale="1">
+        </particlesystem>
+        
+        <!-- Particle system with APEX emitter and non-APEX fallback -->
+        <!-- TheChiprel: APEX emitters are disabled, since they prevent effects from expiring.  -->
+        <!--       At the same time they do nothing visually and probably don't work at all     -->
+        <!--
+        <particlesystem name="system0_apex" space="entity" scale="1">
 
-			<apexemitter asset="carter_W" position="0 0 0"/>
+            <apexemitter asset="carter_W" position="0 0 0"/>
 
-		</particlesystem>
-		
-		
-		
-	</definitions>
-	<thread>
-		<spawnparticlesystem instance="instance0" particlesystem="system0" />
-		<spawnparticlesystem instance="instance1" particlesystem="system0_apex" />
-		<waitfordeath instance="instance0" />
-		<waitfordeath instance="instance1" />
-		<wait duration="6000"/>
-	</thread>
+        </particlesystem>
+        -->
+        
+    </definitions>
+
+    <thread>
+        <spawnparticlesystem instance="instance0" particlesystem="system0" />
+        <!--spawnparticlesystem instance="instance1" particlesystem="system0_apex" /-->
+        <waitfordeath instance="instance0" />
+        <!--waitfordeath instance="instance1" /-->
+    </thread>
 </effect>

--- a/game/heroes/carter/ability_02/effects/impact_lit.effect
+++ b/game/heroes/carter/ability_02/effects/impact_lit.effect
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<effect deferred="true">
+	<definitions>
+		<particlesystem name="system0" space="world" scale="2.25">
+		
+			<sound 
+				falloffstart="500"
+				falloffend="2500"
+				volume=".85"
+				sample="../sounds/sfx_impact.wav"
+			/>
+			
+			<simpleemitter
+				count="100"
+				spawnrate="5000"
+				minparticlelife="250"
+				maxparticlelife="750"
+				gravity="-25"
+				minspeed="100"
+				maxspeed="200"
+				drag=".04"
+				position="0 0 25"
+				pitchspeed="79"
+				material="/shared/effects/smaterials/cartoon_cloud_single.material"
+				offsetsphere="10 10 10"
+				inheritvelocity="0.35"
+				direction="0 0 1"
+				depthbias="45"
+			>
+				<particle
+					color=".25"
+					size="100"
+					startalpha="1"
+					endalpha="0"
+				/>
+			</simpleemitter>
+		
+			<simpleemitter
+				count="100"
+				spawnrate="5000"
+				minparticlelife="250"
+				maxparticlelife="750"
+				gravity="-25"
+				minspeed="100"
+				maxspeed="200"
+				drag=".04"
+				position="0 0 25"
+				pitchspeed="79"
+				material="/shared/effects/smaterials/cartoon_cloud_single.material"
+				offsetsphere="10 10 10"
+				inheritvelocity="0.35"
+				direction="0 0 1"
+				depthbias="45"
+			>
+				<particle
+					color=".5 .75 1"
+					size="100"
+					startalpha="1"
+					endalpha="0"
+				/>
+			</simpleemitter>
+		
+		
+		
+
+			<sound
+				linearfalloff="true" 
+				falloffstart="0"
+				falloffend="2200"
+				volume=".85"
+				sample="../sounds/impact.wav"
+			/>
+
+			<groundsprite
+				position="0 35 0"
+				life="1000"
+				material="/shared/effects/smaterials/puke.material"
+				startsize="40"
+				midsize="65"
+				endsize="65"
+				midsizepos=".05"
+				color=".5 .6 .5"
+				startalpha=".35"
+				midalpha=".35"
+				endalpha="0"
+			/>
+
+			<groundsprite
+				position="0 -10 0"
+				life="1000"
+				material="/shared/effects/smaterials/puke.material"
+				startsize="50"
+				midsize="105"
+				endsize="105"
+				midsizepos=".15"
+				color=".5 .6 .5"
+				startalpha=".35"
+				midalpha=".35"
+				endalpha="0"
+			/>
+
+			<groundsprite
+				position="0 0 0"
+				life="1000"
+				material="/shared/effects/smaterials/whitedot_ground.material"
+				startsize="40"
+				midsize="142"
+				endsize="142"
+				midsizepos=".1"
+				startcolor="0 .2 .4"
+				midcolor="0 .2 .4"
+				endcolor="0 0 0"
+				midcolorpos=".8"
+			/>
+
+			<simpleemitter
+				life="650"
+				spawnrate="16"		
+				particlelife="1000"					
+				position="0 0 0"
+				offsetsphere="85 85 0"
+				direction="0 0 1"
+				minangle="0"
+				maxangle="1"
+				minspeed="0"
+				maxspeed="0"
+			>
+				<particle
+				> 
+					<model
+						minlife="300"
+						maxlife="600"
+						position="0 0 0"
+						model="bubble/model.mdf"
+						anim="idle"
+						color="1 1 1"
+						startalpha="1"
+						midalpha="1"
+						endalpha="0"
+						startscale=".4"
+						midscale=".8"
+						endscale="0"
+						midscalepos=".85"
+					/>
+					
+					<billboard
+						position="0 0 0"
+						life="500"
+						material="/shared/effects/smaterials/whitedot.material"
+						startsize="40"
+						midsize="65"
+						endsize="65"
+						startcolor="0 .25 .5"
+						endcolor="0 0 0"
+						lockup="1"
+						lockright="1"
+						pitch="90"
+						depthbias="-50"
+					/>
+					
+					<billboard
+						position="0 0 10"
+						life="200"
+						param="0.1"
+						startsize="75"
+						endsize="150"
+						startalpha=".25"
+						midalpha=".25"
+						endalpha="0"
+						material="/shared/effects/smaterials/refract_swell.material"
+						lockup="1"
+						lockright="1"
+						pitch="90"
+						depthbias="-50"
+					/>
+				</particle>
+			</simpleemitter>
+
+			<model
+				position="0 8 -5"
+				life="1250"
+				model="puddle/model.mdf"
+				anim="idle"
+				scale="1.4"
+				startalpha="0"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".2"
+			>
+			</model>
+
+			<model
+				position="0 0 0"
+				life="12500"
+				model="junk/model.mdf"
+				anim="idle" 
+				scale=".35"
+				color="1"
+				midscalepos=".1"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".9"
+				minyaw="0"
+				maxyaw="360"
+			>
+			</model>
+
+			<light
+				position="0 0 50"
+				life="1000"
+				startcolor="0 1.5 5"
+				midcolor="0 1.5 5"
+				endcolor="0 0 0"
+				falloffstart="0"
+				falloffend="150"
+			/>
+
+			<billboard
+				position="0 0 50"
+				life="1250"
+				startcolor=".2 .6 1"
+				endcolor="0 0 0"
+				startsize="100"
+				endsize="300"
+				material="/shared/effects/smaterials/whitedot.material"
+				directionalspace="local"
+				depthbias="-50"
+				minroll="-180"
+				maxroll="180"
+				rollspeed="-20"
+			/>
+
+			<simpleemitter
+				position="0 0 0"
+				life="500"
+				gravity="-10"
+				spawnrate="500"
+				minparticlelife="250"
+				maxparticlelife="500"
+				offsetsphere="75 75 50"
+				material="/shared/effects/smaterials/firesprite_blue.material"
+				depthbias="-75"
+			>
+				<particle 
+					minangle="0"
+					maxangle="360"
+					minanglespeed="-6"
+					maxanglespeed="6"
+					startcolor=".5 .75 .1"
+					endcolor="0 0 0"
+					startsize="0"
+					endsize="50"
+				/>
+				<particle 
+					minangle="0"
+					maxangle="360"
+					minanglespeed="-6"
+					maxanglespeed="6"
+					startcolor="0 .35 .1"
+					endcolor="0 0 0"
+					startsize="0"
+					endsize="30"
+				/>
+			</simpleemitter>
+			
+			
+			<simpleemitter
+				count="500"
+				spawnrate="2000"
+				minparticlelife="250"
+				maxparticlelife="750"
+				minspeed="100"
+				maxspeed="1000"
+				drag=".04"
+				position="0 0 25"
+				pitchspeed="79"
+				material="/shared/effects/smaterials/whitedot.material"
+				offsetsphere="5 5 5"
+				inheritvelocity="0.35"
+				direction="0 0 1"
+			>
+				<particle
+					startcolor="1 1 1"
+					midcolor="1 1 1"
+					endcolor="0 .5 1"
+					minsize="2"
+					maxsize="3"
+					depthbias="-50"
+				/>
+			</simpleemitter>
+			
+			
+			
+			
+			<simpleemitter
+				delay="200"
+				life="600"
+				spawnrate="75"
+				gravity="16"
+				minspeed="0"
+				maxpeed="0"
+				minparticlelife="200"
+				maxparticlelife="200"
+				material="/shared/effects/smaterials/muzzle_flash_white.material"
+				offsetsphere="75 75 50"
+				position="0 0 75"
+			>
+				<particle 
+					startcolor=".2 .6 1"
+					midcolor=".6 .7 1"
+					endcolor=".6 .0 1"
+					startsize="25"
+					midsize="10"
+					endsize="0"
+				/>
+			</simpleemitter>
+			
+			
+			
+
+		</particlesystem>
+		
+		
+		
+		
+		
+		
+
+		<!-- Particle system with APEX emitter and non-APEX fallback -->
+		<particlesystem name="system0_apex" space="entity" scale="1">
+
+			<apexemitter asset="carter_W" position="0 0 0"/>
+
+		</particlesystem>
+		
+		
+		
+	</definitions>
+	<thread>
+		<spawnparticlesystem instance="instance0" particlesystem="system0" />
+		<spawnparticlesystem instance="instance1" particlesystem="system0_apex" />
+		<waitfordeath instance="instance0" />
+		<waitfordeath instance="instance1" />
+		<wait duration="6000"/>
+	</thread>
+</effect>

--- a/game/heroes/carter/ability_02/effects/impact_lit.effect
+++ b/game/heroes/carter/ability_02/effects/impact_lit.effect
@@ -1,347 +1,340 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <effect deferred="true">
-	<definitions>
-		<particlesystem name="system0" space="world" scale="2.25">
-		
-			<sound 
-				falloffstart="500"
-				falloffend="2500"
-				volume=".85"
-				sample="../sounds/sfx_impact.wav"
-			/>
-			
-			<simpleemitter
-				count="100"
-				spawnrate="5000"
-				minparticlelife="250"
-				maxparticlelife="750"
-				gravity="-25"
-				minspeed="100"
-				maxspeed="200"
-				drag=".04"
-				position="0 0 25"
-				pitchspeed="79"
-				material="/shared/effects/smaterials/cartoon_cloud_single.material"
-				offsetsphere="10 10 10"
-				inheritvelocity="0.35"
-				direction="0 0 1"
-				depthbias="45"
-			>
-				<particle
-					color=".25"
-					size="100"
-					startalpha="1"
-					endalpha="0"
-				/>
-			</simpleemitter>
-		
-			<simpleemitter
-				count="100"
-				spawnrate="5000"
-				minparticlelife="250"
-				maxparticlelife="750"
-				gravity="-25"
-				minspeed="100"
-				maxspeed="200"
-				drag=".04"
-				position="0 0 25"
-				pitchspeed="79"
-				material="/shared/effects/smaterials/cartoon_cloud_single.material"
-				offsetsphere="10 10 10"
-				inheritvelocity="0.35"
-				direction="0 0 1"
-				depthbias="45"
-			>
-				<particle
-					color=".5 .75 1"
-					size="100"
-					startalpha="1"
-					endalpha="0"
-				/>
-			</simpleemitter>
-		
-		
-		
+    <definitions>
+        <particlesystem name="system0" space="world" scale="2.25">
+        
+            <sound 
+                falloffstart="500"
+                falloffend="2500"
+                volume=".85"
+                sample="../sounds/sfx_impact.wav"
+            />
+            
+            <simpleemitter
+                count="100"
+                spawnrate="5000"
+                minparticlelife="250"
+                maxparticlelife="750"
+                gravity="-25"
+                minspeed="100"
+                maxspeed="200"
+                drag=".04"
+                position="0 0 25"
+                pitchspeed="79"
+                material="/shared/effects/smaterials/cartoon_cloud_single.material"
+                offsetsphere="10 10 10"
+                inheritvelocity="0.35"
+                direction="0 0 1"
+                depthbias="45"
+            >
+                <particle
+                    color=".25"
+                    size="100"
+                    startalpha="1"
+                    endalpha="0"
+                />
+            </simpleemitter>
+        
+            <simpleemitter
+                count="100"
+                spawnrate="5000"
+                minparticlelife="250"
+                maxparticlelife="750"
+                gravity="-25"
+                minspeed="100"
+                maxspeed="200"
+                drag=".04"
+                position="0 0 25"
+                pitchspeed="79"
+                material="/shared/effects/smaterials/cartoon_cloud_single.material"
+                offsetsphere="10 10 10"
+                inheritvelocity="0.35"
+                direction="0 0 1"
+                depthbias="45"
+            >
+                <particle
+                    color=".5 .75 1"
+                    size="100"
+                    startalpha="1"
+                    endalpha="0"
+                />
+            </simpleemitter>
+        
+        
+        
 
-			<sound
-				linearfalloff="true" 
-				falloffstart="0"
-				falloffend="2200"
-				volume=".85"
-				sample="../sounds/impact.wav"
-			/>
+            <sound
+                linearfalloff="true" 
+                falloffstart="0"
+                falloffend="2200"
+                volume=".85"
+                sample="../sounds/impact.wav"
+            />
 
-			<groundsprite
-				position="0 35 0"
-				life="1000"
-				material="/shared/effects/smaterials/puke.material"
-				startsize="40"
-				midsize="65"
-				endsize="65"
-				midsizepos=".05"
-				color=".5 .6 .5"
-				startalpha=".35"
-				midalpha=".35"
-				endalpha="0"
-			/>
+            <groundsprite
+                position="0 35 0"
+                life="1000"
+                material="/shared/effects/smaterials/puke.material"
+                startsize="40"
+                midsize="65"
+                endsize="65"
+                midsizepos=".05"
+                color=".5 .6 .5"
+                startalpha=".35"
+                midalpha=".35"
+                endalpha="0"
+            />
 
-			<groundsprite
-				position="0 -10 0"
-				life="1000"
-				material="/shared/effects/smaterials/puke.material"
-				startsize="50"
-				midsize="105"
-				endsize="105"
-				midsizepos=".15"
-				color=".5 .6 .5"
-				startalpha=".35"
-				midalpha=".35"
-				endalpha="0"
-			/>
+            <groundsprite
+                position="0 -10 0"
+                life="1000"
+                material="/shared/effects/smaterials/puke.material"
+                startsize="50"
+                midsize="105"
+                endsize="105"
+                midsizepos=".15"
+                color=".5 .6 .5"
+                startalpha=".35"
+                midalpha=".35"
+                endalpha="0"
+            />
 
-			<groundsprite
-				position="0 0 0"
-				life="1000"
-				material="/shared/effects/smaterials/whitedot_ground.material"
-				startsize="40"
-				midsize="142"
-				endsize="142"
-				midsizepos=".1"
-				startcolor="0 .2 .4"
-				midcolor="0 .2 .4"
-				endcolor="0 0 0"
-				midcolorpos=".8"
-			/>
+            <groundsprite
+                position="0 0 0"
+                life="1000"
+                material="/shared/effects/smaterials/whitedot_ground.material"
+                startsize="40"
+                midsize="142"
+                endsize="142"
+                midsizepos=".1"
+                startcolor="0 .2 .4"
+                midcolor="0 .2 .4"
+                endcolor="0 0 0"
+                midcolorpos=".8"
+            />
 
-			<simpleemitter
-				life="650"
-				spawnrate="16"		
-				particlelife="1000"					
-				position="0 0 0"
-				offsetsphere="85 85 0"
-				direction="0 0 1"
-				minangle="0"
-				maxangle="1"
-				minspeed="0"
-				maxspeed="0"
-			>
-				<particle
-				> 
-					<model
-						minlife="300"
-						maxlife="600"
-						position="0 0 0"
-						model="bubble/model.mdf"
-						anim="idle"
-						color="1 1 1"
-						startalpha="1"
-						midalpha="1"
-						endalpha="0"
-						startscale=".4"
-						midscale=".8"
-						endscale="0"
-						midscalepos=".85"
-					/>
-					
-					<billboard
-						position="0 0 0"
-						life="500"
-						material="/shared/effects/smaterials/whitedot.material"
-						startsize="40"
-						midsize="65"
-						endsize="65"
-						startcolor="0 .25 .5"
-						endcolor="0 0 0"
-						lockup="1"
-						lockright="1"
-						pitch="90"
-						depthbias="-50"
-					/>
-					
-					<billboard
-						position="0 0 10"
-						life="200"
-						param="0.1"
-						startsize="75"
-						endsize="150"
-						startalpha=".25"
-						midalpha=".25"
-						endalpha="0"
-						material="/shared/effects/smaterials/refract_swell.material"
-						lockup="1"
-						lockright="1"
-						pitch="90"
-						depthbias="-50"
-					/>
-				</particle>
-			</simpleemitter>
+            <simpleemitter
+                life="650"
+                spawnrate="16"		
+                particlelife="1000"					
+                position="0 0 0"
+                offsetsphere="85 85 0"
+                direction="0 0 1"
+                minangle="0"
+                maxangle="1"
+                minspeed="0"
+                maxspeed="0"
+            >
+                <particle
+                > 
+                    <model
+                        minlife="300"
+                        maxlife="600"
+                        position="0 0 0"
+                        model="bubble/model.mdf"
+                        anim="idle"
+                        color="1 1 1"
+                        startalpha="1"
+                        midalpha="1"
+                        endalpha="0"
+                        startscale=".4"
+                        midscale=".8"
+                        endscale="0"
+                        midscalepos=".85"
+                    />
+                    
+                    <billboard
+                        position="0 0 0"
+                        life="500"
+                        material="/shared/effects/smaterials/whitedot.material"
+                        startsize="40"
+                        midsize="65"
+                        endsize="65"
+                        startcolor="0 .25 .5"
+                        endcolor="0 0 0"
+                        lockup="1"
+                        lockright="1"
+                        pitch="90"
+                        depthbias="-50"
+                    />
+                    
+                    <billboard
+                        position="0 0 10"
+                        life="200"
+                        param="0.1"
+                        startsize="75"
+                        endsize="150"
+                        startalpha=".25"
+                        midalpha=".25"
+                        endalpha="0"
+                        material="/shared/effects/smaterials/refract_swell.material"
+                        lockup="1"
+                        lockright="1"
+                        pitch="90"
+                        depthbias="-50"
+                    />
+                </particle>
+            </simpleemitter>
 
-			<model
-				position="0 8 -5"
-				life="1250"
-				model="puddle/model.mdf"
-				anim="idle"
-				scale="1.4"
-				startalpha="0"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".2"
-			>
-			</model>
+            <model
+                position="0 8 -5"
+                life="1250"
+                model="puddle/model.mdf"
+                anim="idle"
+                scale="1.4"
+                startalpha="0"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".2"
+            >
+            </model>
 
-			<model
-				position="0 0 0"
-				life="12500"
-				model="junk/model.mdf"
-				anim="idle" 
-				scale=".35"
-				color="1"
-				midscalepos=".1"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".9"
-				minyaw="0"
-				maxyaw="360"
-			>
-			</model>
+            <model
+                position="0 0 0"
+                life="12500"
+                model="junk/model.mdf"
+                anim="idle" 
+                scale=".35"
+                color="1"
+                midscalepos=".1"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".9"
+                minyaw="0"
+                maxyaw="360"
+            >
+            </model>
 
-			<light
-				position="0 0 50"
-				life="1000"
-				startcolor="0 1.5 5"
-				midcolor="0 1.5 5"
-				endcolor="0 0 0"
-				falloffstart="0"
-				falloffend="150"
-			/>
+            <light
+                position="0 0 50"
+                life="1000"
+                startcolor="0 1.5 5"
+                midcolor="0 1.5 5"
+                endcolor="0 0 0"
+                falloffstart="0"
+                falloffend="150"
+            />
 
-			<billboard
-				position="0 0 50"
-				life="1250"
-				startcolor=".2 .6 1"
-				endcolor="0 0 0"
-				startsize="100"
-				endsize="300"
-				material="/shared/effects/smaterials/whitedot.material"
-				directionalspace="local"
-				depthbias="-50"
-				minroll="-180"
-				maxroll="180"
-				rollspeed="-20"
-			/>
+            <billboard
+                position="0 0 50"
+                life="1250"
+                startcolor=".2 .6 1"
+                endcolor="0 0 0"
+                startsize="100"
+                endsize="300"
+                material="/shared/effects/smaterials/whitedot.material"
+                directionalspace="local"
+                depthbias="-50"
+                minroll="-180"
+                maxroll="180"
+                rollspeed="-20"
+            />
 
-			<simpleemitter
-				position="0 0 0"
-				life="500"
-				gravity="-10"
-				spawnrate="500"
-				minparticlelife="250"
-				maxparticlelife="500"
-				offsetsphere="75 75 50"
-				material="/shared/effects/smaterials/firesprite_blue.material"
-				depthbias="-75"
-			>
-				<particle 
-					minangle="0"
-					maxangle="360"
-					minanglespeed="-6"
-					maxanglespeed="6"
-					startcolor=".5 .75 .1"
-					endcolor="0 0 0"
-					startsize="0"
-					endsize="50"
-				/>
-				<particle 
-					minangle="0"
-					maxangle="360"
-					minanglespeed="-6"
-					maxanglespeed="6"
-					startcolor="0 .35 .1"
-					endcolor="0 0 0"
-					startsize="0"
-					endsize="30"
-				/>
-			</simpleemitter>
-			
-			
-			<simpleemitter
-				count="500"
-				spawnrate="2000"
-				minparticlelife="250"
-				maxparticlelife="750"
-				minspeed="100"
-				maxspeed="1000"
-				drag=".04"
-				position="0 0 25"
-				pitchspeed="79"
-				material="/shared/effects/smaterials/whitedot.material"
-				offsetsphere="5 5 5"
-				inheritvelocity="0.35"
-				direction="0 0 1"
-			>
-				<particle
-					startcolor="1 1 1"
-					midcolor="1 1 1"
-					endcolor="0 .5 1"
-					minsize="2"
-					maxsize="3"
-					depthbias="-50"
-				/>
-			</simpleemitter>
-			
-			
-			
-			
-			<simpleemitter
-				delay="200"
-				life="600"
-				spawnrate="75"
-				gravity="16"
-				minspeed="0"
-				maxpeed="0"
-				minparticlelife="200"
-				maxparticlelife="200"
-				material="/shared/effects/smaterials/muzzle_flash_white.material"
-				offsetsphere="75 75 50"
-				position="0 0 75"
-			>
-				<particle 
-					startcolor=".2 .6 1"
-					midcolor=".6 .7 1"
-					endcolor=".6 .0 1"
-					startsize="25"
-					midsize="10"
-					endsize="0"
-				/>
-			</simpleemitter>
-			
-			
-			
+            <simpleemitter
+                position="0 0 0"
+                life="500"
+                gravity="-10"
+                spawnrate="500"
+                minparticlelife="250"
+                maxparticlelife="500"
+                offsetsphere="75 75 50"
+                material="/shared/effects/smaterials/firesprite_blue.material"
+                depthbias="-75"
+            >
+                <particle 
+                    minangle="0"
+                    maxangle="360"
+                    minanglespeed="-6"
+                    maxanglespeed="6"
+                    startcolor=".5 .75 .1"
+                    endcolor="0 0 0"
+                    startsize="0"
+                    endsize="50"
+                />
+                <particle 
+                    minangle="0"
+                    maxangle="360"
+                    minanglespeed="-6"
+                    maxanglespeed="6"
+                    startcolor="0 .35 .1"
+                    endcolor="0 0 0"
+                    startsize="0"
+                    endsize="30"
+                />
+            </simpleemitter>
+            
+            
+            <simpleemitter
+                count="500"
+                spawnrate="2000"
+                minparticlelife="250"
+                maxparticlelife="750"
+                minspeed="100"
+                maxspeed="1000"
+                drag=".04"
+                position="0 0 25"
+                pitchspeed="79"
+                material="/shared/effects/smaterials/whitedot.material"
+                offsetsphere="5 5 5"
+                inheritvelocity="0.35"
+                direction="0 0 1"
+            >
+                <particle
+                    startcolor="1 1 1"
+                    midcolor="1 1 1"
+                    endcolor="0 .5 1"
+                    minsize="2"
+                    maxsize="3"
+                    depthbias="-50"
+                />
+            </simpleemitter>
+            
+            
+            
+            
+            <simpleemitter
+                delay="200"
+                life="600"
+                spawnrate="75"
+                gravity="16"
+                minspeed="0"
+                maxpeed="0"
+                minparticlelife="200"
+                maxparticlelife="200"
+                material="/shared/effects/smaterials/muzzle_flash_white.material"
+                offsetsphere="75 75 50"
+                position="0 0 75"
+            >
+                <particle 
+                    startcolor=".2 .6 1"
+                    midcolor=".6 .7 1"
+                    endcolor=".6 .0 1"
+                    startsize="25"
+                    midsize="10"
+                    endsize="0"
+                />
+            </simpleemitter>
 
-		</particlesystem>
-		
-		
-		
-		
-		
-		
+        </particlesystem>
 
-		<!-- Particle system with APEX emitter and non-APEX fallback -->
-		<particlesystem name="system0_apex" space="entity" scale="1">
+        <!-- Particle system with APEX emitter and non-APEX fallback -->
+        <!-- TheChiprel: APEX emitters are disabled, since they prevent effects from expiring.  -->
+        <!--       At the same time they do nothing visually and probably don't work at all     -->
+        <!--
+        <particlesystem name="system0_apex" space="entity" scale="1">
 
-			<apexemitter asset="carter_W" position="0 0 0"/>
+            <apexemitter asset="carter_W" position="0 0 0"/>
 
-		</particlesystem>
-		
-		
-		
-	</definitions>
-	<thread>
-		<spawnparticlesystem instance="instance0" particlesystem="system0" />
-		<spawnparticlesystem instance="instance1" particlesystem="system0_apex" />
-		<waitfordeath instance="instance0" />
-		<waitfordeath instance="instance1" />
-		<wait duration="6000"/>
-	</thread>
+        </particlesystem>
+        -->
+        
+    </definitions>
+
+    <thread>
+        <spawnparticlesystem instance="instance0" particlesystem="system0" />
+        <!--spawnparticlesystem instance="instance1" particlesystem="system0_apex" /-->
+        <waitfordeath instance="instance0" />
+        <!--waitfordeath instance="instance1" /-->
+    </thread>
 </effect>

--- a/game/heroes/vermillion/ability_04/effects/explosion.effect
+++ b/game/heroes/vermillion/ability_04/effects/explosion.effect
@@ -1,501 +1,499 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <effect deferred="1">
 
-	<definitions>
+    <definitions>
 
-		<particlesystem name="system0" space="world" scale="1.1">
+        <particlesystem name="system0" space="world" scale="1.1">
 
-			<sound
-				volume="0.85"
-				falloffstart="500"
-				falloffend="2500"
-				sample="../sounds/sfx_impact.wav"
-			/>
+            <sound
+                volume="0.85"
+                falloffstart="500"
+                falloffend="2500"
+                sample="../sounds/sfx_impact.wav"
+            />
 
-			<groundsprite
-				position="0 20 0"
-				life="1100"
-				material="/shared/effects/smaterials/dirtpile_groundsprite.material"
-				startsize="240"
-				midsize="240"
-				endsize="240"
-				midsizepos=".3"
-				color=".7 .6 .4"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".9"
-			/>
+            <groundsprite
+                position="0 20 0"
+                life="1100"
+                material="/shared/effects/smaterials/dirtpile_groundsprite.material"
+                startsize="240"
+                midsize="240"
+                endsize="240"
+                midsizepos=".3"
+                color=".7 .6 .4"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".9"
+            />
 
-			<groundsprite
-				position="0 20 0"
-				life="850"
-				material="/shared/effects/smaterials/big_hole_reveal.material"
-				size="240"
-				color="1 1 1"
-				startframe="1"
-				endframe=".01"
-				startalpha="1"
-				midalpha="1"
-				endalpha="1"
-			/>
-			
-			<groundsprite
-				delay="850"
-				position="0 20 0"
-				life="250"
-				material="/shared/effects/smaterials/big_hole_reveal.material"
-				size="240"
-				color="1 1 1"
-				startalpha="1"
-				endalpha="0"
-			/>
-			
-			
+            <groundsprite
+                position="0 20 0"
+                life="850"
+                material="/shared/effects/smaterials/big_hole_reveal.material"
+                size="240"
+                color="1 1 1"
+                startframe="1"
+                endframe=".01"
+                startalpha="1"
+                midalpha="1"
+                endalpha="1"
+            />
+            
+            <groundsprite
+                delay="850"
+                position="0 20 0"
+                life="250"
+                material="/shared/effects/smaterials/big_hole_reveal.material"
+                size="240"
+                color="1 1 1"
+                startalpha="1"
+                endalpha="0"
+            />
+            
+            
 
-			<simpleemitter		
-				count="200"
-				position="0 0 0"
-				spawnrate="2500"			
-				minparticlelife="500"
-				maxparticlelife="1000"
-				gravity="-10"
-				material="/shared/effects/smaterials/cartoon_cloud_single.material"
-				offsetsphere="0 0 50"
-				direction="0 0 1"
-				minangle="50"
-				maxangle="90"
-				drag="0.01"
-				minspeed="200"
-				maxspeed="400"		
-			>
-				<particle
-					minstartsize="50"				
-					maxstartsize="60"				
-					minendsize="100"
-					maxendsize="200"
-					startcolor="1 1 1"
-					midcolor="1 1 1"
-					endcolor="0 0 0"
-					midcolorpos=".4"
-					startalpha=".8"
-					midalpha=".8"
-					endalpha="0"
-					midalphapos=".25"
-					lockup="true"
-					lockright="true"
-					pitch="-90"
-				/>
-			</simpleemitter>
+            <simpleemitter		
+                count="200"
+                position="0 0 0"
+                spawnrate="2500"			
+                minparticlelife="500"
+                maxparticlelife="1000"
+                gravity="-10"
+                material="/shared/effects/smaterials/cartoon_cloud_single.material"
+                offsetsphere="0 0 50"
+                direction="0 0 1"
+                minangle="50"
+                maxangle="90"
+                drag="0.01"
+                minspeed="200"
+                maxspeed="400"		
+            >
+                <particle
+                    minstartsize="50"				
+                    maxstartsize="60"				
+                    minendsize="100"
+                    maxendsize="200"
+                    startcolor="1 1 1"
+                    midcolor="1 1 1"
+                    endcolor="0 0 0"
+                    midcolorpos=".4"
+                    startalpha=".8"
+                    midalpha=".8"
+                    endalpha="0"
+                    midalphapos=".25"
+                    lockup="true"
+                    lockright="true"
+                    pitch="-90"
+                />
+            </simpleemitter>
 
-			<simpleemitter
-				spawnrate="5000"
-				count="1"
-				particlelife="5000"
-				gravity="-25"
-			>
-				<particle
-				>
-					<billboard
-						position="-15 -25 10"
-						life="900"
-						startsize="150"
-						endsize="500"
-						startcolor="1 1 1"
-						midcolor="1 1 1"
-						endcolor="0 0 0"
-						midcolorpos=".25"
-						startalpha=".6"
-						midalpha=".6"
-						endalpha="0"
-						midalphapos=".25"
-						material="/shared/effects/smaterials/cartoon_cloud.material"
-						lockup="1"
-						lockright="1"
-						pitch="-90"
+            <simpleemitter
+                spawnrate="5000"
+                count="1"
+                particlelife="5000"
+                gravity="-25"
+            >
+                <particle
+                >
+                    <billboard
+                        position="-15 -25 10"
+                        life="900"
+                        startsize="150"
+                        endsize="500"
+                        startcolor="1 1 1"
+                        midcolor="1 1 1"
+                        endcolor="0 0 0"
+                        midcolorpos=".25"
+                        startalpha=".6"
+                        midalpha=".6"
+                        endalpha="0"
+                        midalphapos=".25"
+                        material="/shared/effects/smaterials/cartoon_cloud.material"
+                        lockup="1"
+                        lockright="1"
+                        pitch="-90"
 
-					/>
-				</particle>
-			</simpleemitter>
+                    />
+                </particle>
+            </simpleemitter>
 
-			<simpleemitter
-				spawnrate="5000"
-				count="1"
-				particlelife="5000"
-				gravity="-10"
-			>
-				<particle
-				>
-					<billboard
-						delay="125"
-						position="-15 -25 10"
-						life="900"
-						startsize="150"
-						endsize="600"
-						startcolor="1 1 1"
-						midcolor="1 1 1"
-						endcolor="0 0 0"
-						midcolorpos=".25"
-						startalpha=".6"
-						midalpha=".6"
-						endalpha="0"
-						midalphapos=".25"
-						material="/shared/effects/smaterials/cartoon_cloud.material"
-						lockup="1"
-						lockright="1"
-						pitch="-90"
+            <simpleemitter
+                spawnrate="5000"
+                count="1"
+                particlelife="5000"
+                gravity="-10"
+            >
+                <particle
+                >
+                    <billboard
+                        delay="125"
+                        position="-15 -25 10"
+                        life="900"
+                        startsize="150"
+                        endsize="600"
+                        startcolor="1 1 1"
+                        midcolor="1 1 1"
+                        endcolor="0 0 0"
+                        midcolorpos=".25"
+                        startalpha=".6"
+                        midalpha=".6"
+                        endalpha="0"
+                        midalphapos=".25"
+                        material="/shared/effects/smaterials/cartoon_cloud.material"
+                        lockup="1"
+                        lockright="1"
+                        pitch="-90"
 
-					/>
-				</particle>
-			</simpleemitter>
+                    />
+                </particle>
+            </simpleemitter>
 
-			
+            
 
-			<model
-				startcolor="1 .75 .25"
-				midcolor=".75 .65 .55"
-				endcolor=".75 .65 .55"
-				midcolorpos=".1"
-				model="explosion_higher/model.mdf"
-				anim="idle"
-				startscale="1.3"
-				midscale="1.6"
-				endscale="2"
-				midscalepos=".2"
-				life="10000"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".95"
-				yaw="90"
-			/>
+            <model
+                startcolor="1 .75 .25"
+                midcolor=".75 .65 .55"
+                endcolor=".75 .65 .55"
+                midcolorpos=".1"
+                model="explosion_higher/model.mdf"
+                anim="idle"
+                startscale="1.3"
+                midscale="1.6"
+                endscale="2"
+                midscalepos=".2"
+                life="10000"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".95"
+                yaw="90"
+            />
 
-			
+            
 
 <!--
-			<model
-				startcolor="1 .5 0"
-				midcolor="1 .5 0"
-				endcolor="0 0 0"
-				model="explosion_higher/model.mdf"
-				anim="idle"
-				scale="1.1"
-				life="900"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".55"
-				position="0 0 -50"
-				yaw="0"
-			/>
-			
-			<model
-				startcolor="1 .5 0"
-				midcolor="1 .5 0"
-				endcolor="0 0 0"
-				model="explosion_higher/model.mdf"
-				anim="idle"
-				scale="1.1"
-				life="900"
-				startalpha="1"
-				midalpha="1"
-				endalpha="0"
-				midalphapos=".55"
-				position="0 0 -50"
-				yaw="180"
-			/>
+            <model
+                startcolor="1 .5 0"
+                midcolor="1 .5 0"
+                endcolor="0 0 0"
+                model="explosion_higher/model.mdf"
+                anim="idle"
+                scale="1.1"
+                life="900"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".55"
+                position="0 0 -50"
+                yaw="0"
+            />
+            
+            <model
+                startcolor="1 .5 0"
+                midcolor="1 .5 0"
+                endcolor="0 0 0"
+                model="explosion_higher/model.mdf"
+                anim="idle"
+                scale="1.1"
+                life="900"
+                startalpha="1"
+                midalpha="1"
+                endalpha="0"
+                midalphapos=".55"
+                position="0 0 -50"
+                yaw="180"
+            />
 -->
 
-			<simpleemitter
-				count="30"
-				spawnrate="9000"
-				particlelife="500"
-				minspeed="250"
-				maxspeed="500"
-				drag="0"
-				acceleration="0"
-				minangle="0"
-				maxangle="10"
-				direction="0 0 1"
-				offsetsphere="25 25 60"
-				particledirectionalspace="local"
-			>
-				<particle>
-					<trailemitter
-						life="750"
-						spawnrate="20"
-						particlelife="750"
-						texpostime="750"
-						texposscale="0"
-						texstretchscale="1"
-						material="/shared/effects/smaterials/single_cartoon_wack.material"
-						startparticlecolor="1 1 1"
-						endparticlecolor="1 1 1"
-						startparticlealpha="1"
-						endparticlealpha="0"
-						depthbias="-20"
-					>
-						<particle
-							startalpha="1"
-							midalpha=".5"
-							endalpha="0"
-							midalphapos=".35"
-							startcolor="1 1 1"
-							endcolor="1 0 0"
-							startsize="55"
-							midsize="44"
-							endsize="22"
-							midsizepos="0.2"
-						/>
-					</trailemitter>
-				</particle>
-			</simpleemitter>
+            <simpleemitter
+                count="30"
+                spawnrate="9000"
+                particlelife="500"
+                minspeed="250"
+                maxspeed="500"
+                drag="0"
+                acceleration="0"
+                minangle="0"
+                maxangle="10"
+                direction="0 0 1"
+                offsetsphere="25 25 60"
+                particledirectionalspace="local"
+            >
+                <particle>
+                    <trailemitter
+                        life="750"
+                        spawnrate="20"
+                        particlelife="750"
+                        texpostime="750"
+                        texposscale="0"
+                        texstretchscale="1"
+                        material="/shared/effects/smaterials/single_cartoon_wack.material"
+                        startparticlecolor="1 1 1"
+                        endparticlecolor="1 1 1"
+                        startparticlealpha="1"
+                        endparticlealpha="0"
+                        depthbias="-20"
+                    >
+                        <particle
+                            startalpha="1"
+                            midalpha=".5"
+                            endalpha="0"
+                            midalphapos=".35"
+                            startcolor="1 1 1"
+                            endcolor="1 0 0"
+                            startsize="55"
+                            midsize="44"
+                            endsize="22"
+                            midsizepos="0.2"
+                        />
+                    </trailemitter>
+                </particle>
+            </simpleemitter>
 
-			<simpleemitter
-				count="20"
-				spawnrate="9000"
-				particlelife="500"
-				minspeed="250"
-				maxspeed="500"
-				drag="0"
-				acceleration="0"
-				minangle="0"
-				maxangle="10"
-				direction="0 0 1"
-				offsetsphere="25 25 0"
-				particledirectionalspace="local"
-			>
-				<particle>
-					<trailemitter
-						life="750"
-						spawnrate="20"
-						particlelife="500"
-						texpostime="500"
-						texposscale="0"
-						texstretchscale="1"
-						material="/shared/effects/smaterials/whitedot.material"
-						startparticlecolor="0 0 0"
-						midparticlecolor=".5 .5 .5"
-						endparticlecolor="0 0 0"
-						depthbias="-20"
-					>
-						<particle
-							startcolor=".25 .25 .25"
-							midcolor=".5 .25 0"
-							endcolor="0 0 0"
-							midcolorpos=".2"
-							startsize="55"
-							midsize="44"
-							endsize="22"
-							midsizepos="0.2"
-						/>
-					</trailemitter>
-				</particle>
-			</simpleemitter>
+            <simpleemitter
+                count="20"
+                spawnrate="9000"
+                particlelife="500"
+                minspeed="250"
+                maxspeed="500"
+                drag="0"
+                acceleration="0"
+                minangle="0"
+                maxangle="10"
+                direction="0 0 1"
+                offsetsphere="25 25 0"
+                particledirectionalspace="local"
+            >
+                <particle>
+                    <trailemitter
+                        life="750"
+                        spawnrate="20"
+                        particlelife="500"
+                        texpostime="500"
+                        texposscale="0"
+                        texstretchscale="1"
+                        material="/shared/effects/smaterials/whitedot.material"
+                        startparticlecolor="0 0 0"
+                        midparticlecolor=".5 .5 .5"
+                        endparticlecolor="0 0 0"
+                        depthbias="-20"
+                    >
+                        <particle
+                            startcolor=".25 .25 .25"
+                            midcolor=".5 .25 0"
+                            endcolor="0 0 0"
+                            midcolorpos=".2"
+                            startsize="55"
+                            midsize="44"
+                            endsize="22"
+                            midsizepos="0.2"
+                        />
+                    </trailemitter>
+                </particle>
+            </simpleemitter>
 
-			<simpleemitter		
-				count="25"
-				position="0 0 0"
-				spawnrate="2500"			
-				minparticlelife="500"
-				maxparticlelife="1000"
-				gravity="0"
-				material="/shared/effects/smaterials/whitedot.material"
-				offsetsphere="0 0 0"
-				direction="0 0 1"
-				minangle="50"
-				maxangle="90"
-				drag="0.01"
-				minspeed="50"
-				maxspeed="100"		
-			>
-				<particle
-					minstartsize="50"				
-					maxstartsize="60"				
-					minendsize="100"
-					maxendsize="200"
-					startcolor=".125 .05 0"
-					midcolor=".125 .05 0"
-					endcolor="0 0 0"
-					midcolorpos=".4"
-					startalpha=".8"
-					midalpha=".8"
-					endalpha="0"
-					midalphapos=".25"
-					lockup="true"
-					lockright="true"
-					pitch="-90"
-				/>
-			</simpleemitter>
+            <simpleemitter		
+                count="25"
+                position="0 0 0"
+                spawnrate="2500"			
+                minparticlelife="500"
+                maxparticlelife="1000"
+                gravity="0"
+                material="/shared/effects/smaterials/whitedot.material"
+                offsetsphere="0 0 0"
+                direction="0 0 1"
+                minangle="50"
+                maxangle="90"
+                drag="0.01"
+                minspeed="50"
+                maxspeed="100"		
+            >
+                <particle
+                    minstartsize="50"				
+                    maxstartsize="60"				
+                    minendsize="100"
+                    maxendsize="200"
+                    startcolor=".125 .05 0"
+                    midcolor=".125 .05 0"
+                    endcolor="0 0 0"
+                    midcolorpos=".4"
+                    startalpha=".8"
+                    midalpha=".8"
+                    endalpha="0"
+                    midalphapos=".25"
+                    lockup="true"
+                    lockright="true"
+                    pitch="-90"
+                />
+            </simpleemitter>
 
-			<billboard
-				position="0 0 50"
-				life="750"
-				param="0.1"
-				startsize="100"
-				endsize="900"
-				startalpha="0"
-				midalpha=".75"
-				endalpha="0"
-				midalphapos=".1"
-				material="/shared/effects/smaterials/refract_swell.material"
-				lockup="1"
-				lockright="1"
-				pitch="90"
-			/>
+            <billboard
+                position="0 0 50"
+                life="750"
+                param="0.1"
+                startsize="100"
+                endsize="900"
+                startalpha="0"
+                midalpha=".75"
+                endalpha="0"
+                midalphapos=".1"
+                material="/shared/effects/smaterials/refract_swell.material"
+                lockup="1"
+                lockright="1"
+                pitch="90"
+            />
 
-			<simpleemitter
-				position="0 0 100"
-				life="500"
-				spawnrate="500"
-				minparticlelife="250"
-				maxparticlelife="750"
-				gravity="150"
-				speed="1000"
-				offsetsphere="25 25 200"
-				material="/shared/effects/smaterials/whitedot.material"
-				minangle="0"
-				maxangle="5"
-				direction="0 0 1"
-				depthbias="-25"
-			>
-				<particle 
-					startcolor="1 .5 0"
-					midcolor="1 .5 0"
-					endcolor="0 0 0"
-					midcolorpos=".25"
-					startsize="2"
-					midsize="6"
-					endsize="6"
-				/>
-			</simpleemitter>
-			
-			
-			<simpleemitter
-				count="300"
-				position="0 0 100"
-				life="500"
-				spawnrate="5000"
-				minparticlelife="250"
-				maxparticlelife="750"
-				gravity="0"
-				minspeed="300"
-				maxspeed="500"
-				offsetsphere="25 25 25"
-				material="/shared/effects/smaterials/whitedot.material"
-				depthbias="-25"
-			>
-				<particle 
-					startcolor="1 .5 0"
-					midcolor="1 .5 0"
-					endcolor="0 0 0"
-					midcolorpos=".25"
-					startsize="2"
-					midsize="10"
-					endsize="10"
-				/>
-			</simpleemitter>
+            <simpleemitter
+                position="0 0 100"
+                life="500"
+                spawnrate="500"
+                minparticlelife="250"
+                maxparticlelife="750"
+                gravity="150"
+                speed="1000"
+                offsetsphere="25 25 200"
+                material="/shared/effects/smaterials/whitedot.material"
+                minangle="0"
+                maxangle="5"
+                direction="0 0 1"
+                depthbias="-25"
+            >
+                <particle 
+                    startcolor="1 .5 0"
+                    midcolor="1 .5 0"
+                    endcolor="0 0 0"
+                    midcolorpos=".25"
+                    startsize="2"
+                    midsize="6"
+                    endsize="6"
+                />
+            </simpleemitter>
+            
+            
+            <simpleemitter
+                count="300"
+                position="0 0 100"
+                life="500"
+                spawnrate="5000"
+                minparticlelife="250"
+                maxparticlelife="750"
+                gravity="0"
+                minspeed="300"
+                maxspeed="500"
+                offsetsphere="25 25 25"
+                material="/shared/effects/smaterials/whitedot.material"
+                depthbias="-25"
+            >
+                <particle 
+                    startcolor="1 .5 0"
+                    midcolor="1 .5 0"
+                    endcolor="0 0 0"
+                    midcolorpos=".25"
+                    startsize="2"
+                    midsize="10"
+                    endsize="10"
+                />
+            </simpleemitter>
 
-			<light
-				position="0 0 100"
-				life="450"
-				startcolor="10 6 2"
-				midcolor="5 .5 0"
-				endcolor="0 0 0"
-				midcolorpos=".2"
-				falloffstart="75"
-				falloffend="230"
-			/>
+            <light
+                position="0 0 100"
+                life="450"
+                startcolor="10 6 2"
+                midcolor="5 .5 0"
+                endcolor="0 0 0"
+                midcolorpos=".2"
+                falloffstart="75"
+                falloffend="230"
+            />
 
 
 
-			<model
-				position="0 0 65"
-				life="2000"
-				model="fx_rig/model.mdf"
-				anim="idle"
-				color="1 1 1"
-				alpha="1"
-				scale="3.5"
-				lockup="true"
-				lockright="true"
-			>
-				<template name="flashes">
-					<billboard
-						bone="{bone}"
-						life="200"
-						startcolor="1 .8 .4"
-						midcolor="1 .8 .4"
-						endcolor=".5 0 0"
-						startalpha=".5"
-						endalpha="0"
-						midalphapos=".85"
-						minstartsize="75"
-						maxstartsize="110"
-						endsize="75"
-						lockright="1"
-						lockup="1"
-						pitch="90"
-						roll="-90"
-						yaw="90"
-						material="/shared/effects/smaterials/single_cartoon_wack.material"
-						directionalspace="local"
-						depthbias="-50"
-					/>
-					
-				</template>
+            <model
+                position="0 0 65"
+                life="2000"
+                model="fx_rig/model.mdf"
+                anim="idle"
+                color="1 1 1"
+                alpha="1"
+                scale="3.5"
+                lockup="true"
+                lockright="true"
+            >
+                <template name="flashes">
+                    <billboard
+                        bone="{bone}"
+                        life="200"
+                        startcolor="1 .8 .4"
+                        midcolor="1 .8 .4"
+                        endcolor=".5 0 0"
+                        startalpha=".5"
+                        endalpha="0"
+                        midalphapos=".85"
+                        minstartsize="75"
+                        maxstartsize="110"
+                        endsize="75"
+                        lockright="1"
+                        lockup="1"
+                        pitch="90"
+                        roll="-90"
+                        yaw="90"
+                        material="/shared/effects/smaterials/single_cartoon_wack.material"
+                        directionalspace="local"
+                        depthbias="-50"
+                    />
+                    
+                </template>
 
-				<instance name="flashes" bone="_bone_fx_01" />
-				<instance name="flashes" bone="_bone_fx_02" />
-				<instance name="flashes" bone="_bone_fx_03" />
-				<instance name="flashes" bone="_bone_fx_04" />
-				
-				<instance name="flashes" bone="_bone_fx_05" />
-				<instance name="flashes" bone="_bone_fx_06" />
-				<instance name="flashes" bone="_bone_fx_07" />
-				<instance name="flashes" bone="_bone_fx_08" />
-				
-			</model>
+                <instance name="flashes" bone="_bone_fx_01" />
+                <instance name="flashes" bone="_bone_fx_02" />
+                <instance name="flashes" bone="_bone_fx_03" />
+                <instance name="flashes" bone="_bone_fx_04" />
+                
+                <instance name="flashes" bone="_bone_fx_05" />
+                <instance name="flashes" bone="_bone_fx_06" />
+                <instance name="flashes" bone="_bone_fx_07" />
+                <instance name="flashes" bone="_bone_fx_08" />
+                
+            </model>
 
-			<billboard
-			position="0 0 50"
-				life="1000"
-				startcolor=".5 .25 0"
-				endcolor="0 0 0"
-				startsize="750"
-				endsize="75"
-				lockright="1"
-				lockup="1"
-				pitch="90"
-				material="/shared/effects/smaterials/whitedot.material"
-				depthbias="-50"
-			/>
+            <billboard
+            position="0 0 50"
+                life="1000"
+                startcolor=".5 .25 0"
+                endcolor="0 0 0"
+                startsize="750"
+                endsize="75"
+                lockright="1"
+                lockup="1"
+                pitch="90"
+                material="/shared/effects/smaterials/whitedot.material"
+                depthbias="-50"
+            />
 
-		</particlesystem>
+        </particlesystem>
 
-		<!-- Particle system with APEX emitter and non-APEX fallback -->
-		<particlesystem name="system0_apex" space="entity" scale="1">
+        <!-- Particle system with APEX emitter and non-APEX fallback -->
+        <!-- TheChiprel: APEX emitters are disabled, since they prevent effects from expiring.  -->
+        <!--       At the same time they do nothing visually and probably don't work at all     -->
+        <!--
+        <particlesystem name="system0_apex" space="entity" scale="1">
 
-			<apexemitter asset="vermillion_R" position="0 0 0" />
+            <apexemitter asset="vermillion_R" position="0 0 0" />
 
-		</particlesystem>
+        </particlesystem>
+        -->
 
-	</definitions>
-	
-	
-	
+    </definitions>
+    
+    
+    
 
-	<thread>
-
-		<camerashake2 scale="15" radius="5000" duration="400" frequency="30" />
-		
-		<spawnparticlesystem instance="instance0" particlesystem="system0" />
-		<spawnparticlesystem instance="instance1" particlesystem="system0_apex" />
-        <print text="inst1 started"/>
-		<waitfordeath instance="instance0" />
-		<waitfordeath instance="instance1" />
-        <print text="inst1 ended"/>
-		<wait duration="2000"/>
-
-	</thread>
+    <thread>
+        <camerashake2 scale="15" radius="5000" duration="400" frequency="30" />
+        <spawnparticlesystem instance="instance0" particlesystem="system0" />
+        <!--spawnparticlesystem instance="instance1" particlesystem="system0_apex" /-->
+        <waitfordeath instance="instance0" />
+        <!--waitfordeath instance="instance1" /-->
+    </thread>
 </effect>

--- a/game/heroes/vermillion/ability_04/effects/explosion.effect
+++ b/game/heroes/vermillion/ability_04/effects/explosion.effect
@@ -1,0 +1,501 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<effect deferred="1">
+
+	<definitions>
+
+		<particlesystem name="system0" space="world" scale="1.1">
+
+			<sound
+				volume="0.85"
+				falloffstart="500"
+				falloffend="2500"
+				sample="../sounds/sfx_impact.wav"
+			/>
+
+			<groundsprite
+				position="0 20 0"
+				life="1100"
+				material="/shared/effects/smaterials/dirtpile_groundsprite.material"
+				startsize="240"
+				midsize="240"
+				endsize="240"
+				midsizepos=".3"
+				color=".7 .6 .4"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".9"
+			/>
+
+			<groundsprite
+				position="0 20 0"
+				life="850"
+				material="/shared/effects/smaterials/big_hole_reveal.material"
+				size="240"
+				color="1 1 1"
+				startframe="1"
+				endframe=".01"
+				startalpha="1"
+				midalpha="1"
+				endalpha="1"
+			/>
+			
+			<groundsprite
+				delay="850"
+				position="0 20 0"
+				life="250"
+				material="/shared/effects/smaterials/big_hole_reveal.material"
+				size="240"
+				color="1 1 1"
+				startalpha="1"
+				endalpha="0"
+			/>
+			
+			
+
+			<simpleemitter		
+				count="200"
+				position="0 0 0"
+				spawnrate="2500"			
+				minparticlelife="500"
+				maxparticlelife="1000"
+				gravity="-10"
+				material="/shared/effects/smaterials/cartoon_cloud_single.material"
+				offsetsphere="0 0 50"
+				direction="0 0 1"
+				minangle="50"
+				maxangle="90"
+				drag="0.01"
+				minspeed="200"
+				maxspeed="400"		
+			>
+				<particle
+					minstartsize="50"				
+					maxstartsize="60"				
+					minendsize="100"
+					maxendsize="200"
+					startcolor="1 1 1"
+					midcolor="1 1 1"
+					endcolor="0 0 0"
+					midcolorpos=".4"
+					startalpha=".8"
+					midalpha=".8"
+					endalpha="0"
+					midalphapos=".25"
+					lockup="true"
+					lockright="true"
+					pitch="-90"
+				/>
+			</simpleemitter>
+
+			<simpleemitter
+				spawnrate="5000"
+				count="1"
+				particlelife="5000"
+				gravity="-25"
+			>
+				<particle
+				>
+					<billboard
+						position="-15 -25 10"
+						life="900"
+						startsize="150"
+						endsize="500"
+						startcolor="1 1 1"
+						midcolor="1 1 1"
+						endcolor="0 0 0"
+						midcolorpos=".25"
+						startalpha=".6"
+						midalpha=".6"
+						endalpha="0"
+						midalphapos=".25"
+						material="/shared/effects/smaterials/cartoon_cloud.material"
+						lockup="1"
+						lockright="1"
+						pitch="-90"
+
+					/>
+				</particle>
+			</simpleemitter>
+
+			<simpleemitter
+				spawnrate="5000"
+				count="1"
+				particlelife="5000"
+				gravity="-10"
+			>
+				<particle
+				>
+					<billboard
+						delay="125"
+						position="-15 -25 10"
+						life="900"
+						startsize="150"
+						endsize="600"
+						startcolor="1 1 1"
+						midcolor="1 1 1"
+						endcolor="0 0 0"
+						midcolorpos=".25"
+						startalpha=".6"
+						midalpha=".6"
+						endalpha="0"
+						midalphapos=".25"
+						material="/shared/effects/smaterials/cartoon_cloud.material"
+						lockup="1"
+						lockright="1"
+						pitch="-90"
+
+					/>
+				</particle>
+			</simpleemitter>
+
+			
+
+			<model
+				startcolor="1 .75 .25"
+				midcolor=".75 .65 .55"
+				endcolor=".75 .65 .55"
+				midcolorpos=".1"
+				model="explosion_higher/model.mdf"
+				anim="idle"
+				startscale="1.3"
+				midscale="1.6"
+				endscale="2"
+				midscalepos=".2"
+				life="10000"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".95"
+				yaw="90"
+			/>
+
+			
+
+<!--
+			<model
+				startcolor="1 .5 0"
+				midcolor="1 .5 0"
+				endcolor="0 0 0"
+				model="explosion_higher/model.mdf"
+				anim="idle"
+				scale="1.1"
+				life="900"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".55"
+				position="0 0 -50"
+				yaw="0"
+			/>
+			
+			<model
+				startcolor="1 .5 0"
+				midcolor="1 .5 0"
+				endcolor="0 0 0"
+				model="explosion_higher/model.mdf"
+				anim="idle"
+				scale="1.1"
+				life="900"
+				startalpha="1"
+				midalpha="1"
+				endalpha="0"
+				midalphapos=".55"
+				position="0 0 -50"
+				yaw="180"
+			/>
+-->
+
+			<simpleemitter
+				count="30"
+				spawnrate="9000"
+				particlelife="500"
+				minspeed="250"
+				maxspeed="500"
+				drag="0"
+				acceleration="0"
+				minangle="0"
+				maxangle="10"
+				direction="0 0 1"
+				offsetsphere="25 25 60"
+				particledirectionalspace="local"
+			>
+				<particle>
+					<trailemitter
+						life="750"
+						spawnrate="20"
+						particlelife="750"
+						texpostime="750"
+						texposscale="0"
+						texstretchscale="1"
+						material="/shared/effects/smaterials/single_cartoon_wack.material"
+						startparticlecolor="1 1 1"
+						endparticlecolor="1 1 1"
+						startparticlealpha="1"
+						endparticlealpha="0"
+						depthbias="-20"
+					>
+						<particle
+							startalpha="1"
+							midalpha=".5"
+							endalpha="0"
+							midalphapos=".35"
+							startcolor="1 1 1"
+							endcolor="1 0 0"
+							startsize="55"
+							midsize="44"
+							endsize="22"
+							midsizepos="0.2"
+						/>
+					</trailemitter>
+				</particle>
+			</simpleemitter>
+
+			<simpleemitter
+				count="20"
+				spawnrate="9000"
+				particlelife="500"
+				minspeed="250"
+				maxspeed="500"
+				drag="0"
+				acceleration="0"
+				minangle="0"
+				maxangle="10"
+				direction="0 0 1"
+				offsetsphere="25 25 0"
+				particledirectionalspace="local"
+			>
+				<particle>
+					<trailemitter
+						life="750"
+						spawnrate="20"
+						particlelife="500"
+						texpostime="500"
+						texposscale="0"
+						texstretchscale="1"
+						material="/shared/effects/smaterials/whitedot.material"
+						startparticlecolor="0 0 0"
+						midparticlecolor=".5 .5 .5"
+						endparticlecolor="0 0 0"
+						depthbias="-20"
+					>
+						<particle
+							startcolor=".25 .25 .25"
+							midcolor=".5 .25 0"
+							endcolor="0 0 0"
+							midcolorpos=".2"
+							startsize="55"
+							midsize="44"
+							endsize="22"
+							midsizepos="0.2"
+						/>
+					</trailemitter>
+				</particle>
+			</simpleemitter>
+
+			<simpleemitter		
+				count="25"
+				position="0 0 0"
+				spawnrate="2500"			
+				minparticlelife="500"
+				maxparticlelife="1000"
+				gravity="0"
+				material="/shared/effects/smaterials/whitedot.material"
+				offsetsphere="0 0 0"
+				direction="0 0 1"
+				minangle="50"
+				maxangle="90"
+				drag="0.01"
+				minspeed="50"
+				maxspeed="100"		
+			>
+				<particle
+					minstartsize="50"				
+					maxstartsize="60"				
+					minendsize="100"
+					maxendsize="200"
+					startcolor=".125 .05 0"
+					midcolor=".125 .05 0"
+					endcolor="0 0 0"
+					midcolorpos=".4"
+					startalpha=".8"
+					midalpha=".8"
+					endalpha="0"
+					midalphapos=".25"
+					lockup="true"
+					lockright="true"
+					pitch="-90"
+				/>
+			</simpleemitter>
+
+			<billboard
+				position="0 0 50"
+				life="750"
+				param="0.1"
+				startsize="100"
+				endsize="900"
+				startalpha="0"
+				midalpha=".75"
+				endalpha="0"
+				midalphapos=".1"
+				material="/shared/effects/smaterials/refract_swell.material"
+				lockup="1"
+				lockright="1"
+				pitch="90"
+			/>
+
+			<simpleemitter
+				position="0 0 100"
+				life="500"
+				spawnrate="500"
+				minparticlelife="250"
+				maxparticlelife="750"
+				gravity="150"
+				speed="1000"
+				offsetsphere="25 25 200"
+				material="/shared/effects/smaterials/whitedot.material"
+				minangle="0"
+				maxangle="5"
+				direction="0 0 1"
+				depthbias="-25"
+			>
+				<particle 
+					startcolor="1 .5 0"
+					midcolor="1 .5 0"
+					endcolor="0 0 0"
+					midcolorpos=".25"
+					startsize="2"
+					midsize="6"
+					endsize="6"
+				/>
+			</simpleemitter>
+			
+			
+			<simpleemitter
+				count="300"
+				position="0 0 100"
+				life="500"
+				spawnrate="5000"
+				minparticlelife="250"
+				maxparticlelife="750"
+				gravity="0"
+				minspeed="300"
+				maxspeed="500"
+				offsetsphere="25 25 25"
+				material="/shared/effects/smaterials/whitedot.material"
+				depthbias="-25"
+			>
+				<particle 
+					startcolor="1 .5 0"
+					midcolor="1 .5 0"
+					endcolor="0 0 0"
+					midcolorpos=".25"
+					startsize="2"
+					midsize="10"
+					endsize="10"
+				/>
+			</simpleemitter>
+
+			<light
+				position="0 0 100"
+				life="450"
+				startcolor="10 6 2"
+				midcolor="5 .5 0"
+				endcolor="0 0 0"
+				midcolorpos=".2"
+				falloffstart="75"
+				falloffend="230"
+			/>
+
+
+
+			<model
+				position="0 0 65"
+				life="2000"
+				model="fx_rig/model.mdf"
+				anim="idle"
+				color="1 1 1"
+				alpha="1"
+				scale="3.5"
+				lockup="true"
+				lockright="true"
+			>
+				<template name="flashes">
+					<billboard
+						bone="{bone}"
+						life="200"
+						startcolor="1 .8 .4"
+						midcolor="1 .8 .4"
+						endcolor=".5 0 0"
+						startalpha=".5"
+						endalpha="0"
+						midalphapos=".85"
+						minstartsize="75"
+						maxstartsize="110"
+						endsize="75"
+						lockright="1"
+						lockup="1"
+						pitch="90"
+						roll="-90"
+						yaw="90"
+						material="/shared/effects/smaterials/single_cartoon_wack.material"
+						directionalspace="local"
+						depthbias="-50"
+					/>
+					
+				</template>
+
+				<instance name="flashes" bone="_bone_fx_01" />
+				<instance name="flashes" bone="_bone_fx_02" />
+				<instance name="flashes" bone="_bone_fx_03" />
+				<instance name="flashes" bone="_bone_fx_04" />
+				
+				<instance name="flashes" bone="_bone_fx_05" />
+				<instance name="flashes" bone="_bone_fx_06" />
+				<instance name="flashes" bone="_bone_fx_07" />
+				<instance name="flashes" bone="_bone_fx_08" />
+				
+			</model>
+
+			<billboard
+			position="0 0 50"
+				life="1000"
+				startcolor=".5 .25 0"
+				endcolor="0 0 0"
+				startsize="750"
+				endsize="75"
+				lockright="1"
+				lockup="1"
+				pitch="90"
+				material="/shared/effects/smaterials/whitedot.material"
+				depthbias="-50"
+			/>
+
+		</particlesystem>
+
+		<!-- Particle system with APEX emitter and non-APEX fallback -->
+		<particlesystem name="system0_apex" space="entity" scale="1">
+
+			<apexemitter asset="vermillion_R" position="0 0 0" />
+
+		</particlesystem>
+
+	</definitions>
+	
+	
+	
+
+	<thread>
+
+		<camerashake2 scale="15" radius="5000" duration="400" frequency="30" />
+		
+		<spawnparticlesystem instance="instance0" particlesystem="system0" />
+		<spawnparticlesystem instance="instance1" particlesystem="system0_apex" />
+        <print text="inst1 started"/>
+		<waitfordeath instance="instance0" />
+		<waitfordeath instance="instance1" />
+        <print text="inst1 ended"/>
+		<wait duration="2000"/>
+
+	</thread>
+</effect>


### PR DESCRIPTION
After a brief examination I found out that Apex Emitters never expire, therefore they never let effect containing them expire as well. Moreover they seem never work at the first place, since disabling them make absolutely no visual difference and keeping only them active creates no visual effects. Therefore I disabled those for heroes, luckily there were just three abilities using them:
- Carter's W;
- Ace's W;
- Vermillion's R.

This can be considered as a hotfix and other effects should also be looked at or, maybe, Apex Emitters should be ignored in code altogether since they do nothing.